### PR TITLE
Compare timepoints correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 master
 ------
 
+- (`#73 <https://github.com/openscm/scmdata/pull/73>`_) Only reindex timeseries when dealing with different time points
+
 v0.5.2
 ------
 

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -1830,7 +1830,7 @@ def run_append(
     # reindex if the timebase isn't the same
     all_valid_times = True
     for r in runs:
-        if not np.array_equal(new_t, r.time_points):
+        if not np.array_equal(new_t, r.time_points.values):
             all_valid_times = False
     if not all_valid_times:
         # Time values are converted to cftime to avoid OutOfBoundsDatetime errors

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -13,7 +13,7 @@ from numpy import testing as npt
 from pandas.errors import UnsupportedFunctionCall
 from pint.errors import DimensionalityError, UndefinedUnitError
 
-from scmdata.run import ScmRun, df_append, run_append, TimeSeries
+from scmdata.run import ScmRun, TimeSeries, df_append, run_append
 from scmdata.testing import assert_scmdf_almost_equal
 
 
@@ -1358,10 +1358,14 @@ def test_append_reindexing(test_scm_run, same_times):
     if not same_times:
         other["time"] = [2002, 2010, 2020]
 
-    with patch.object(TimeSeries, "reindex", wraps=other._ts[0].reindex) as mock_reindex:
+    with patch.object(
+        TimeSeries, "reindex", wraps=other._ts[0].reindex
+    ) as mock_reindex:
         res = test_scm_run.append(other)
 
-        expected_times = set(np.concatenate([other.time_points.values, test_scm_run.time_points.values]))
+        expected_times = set(
+            np.concatenate([other.time_points.values, test_scm_run.time_points.values])
+        )
         if same_times:
             mock_reindex.assert_not_called()
         else:

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -13,7 +13,7 @@ from numpy import testing as npt
 from pandas.errors import UnsupportedFunctionCall
 from pint.errors import DimensionalityError, UndefinedUnitError
 
-from scmdata.run import ScmRun, df_append, run_append
+from scmdata.run import ScmRun, df_append, run_append, TimeSeries
 from scmdata.testing import assert_scmdf_almost_equal
 
 
@@ -1349,6 +1349,27 @@ def test_append_inplace_preexisting_nan(test_scm_run):
         exp.sort_index().reset_index(),
         check_like=True,
     )
+
+
+@pytest.mark.parametrize("same_times", [True, False])
+def test_append_reindexing(test_scm_run, same_times):
+    other = copy.deepcopy(test_scm_run)
+    other["climate_model"] = "other"
+    if not same_times:
+        other["time"] = [2002, 2010, 2020]
+
+    with patch.object(TimeSeries, "reindex", wraps=other._ts[0].reindex) as mock_reindex:
+        res = test_scm_run.append(other)
+
+        expected_times = set(np.concatenate([other.time_points.values, test_scm_run.time_points.values]))
+        if same_times:
+            mock_reindex.assert_not_called()
+        else:
+            mock_reindex.assert_called()
+
+        npt.assert_array_equal(res.time_points.values, sorted(expected_times))
+        for t in res._ts:
+            npt.assert_array_equal(t.time_points.values, sorted(expected_times))
 
 
 def test_interpolate(combo_df):


### PR DESCRIPTION
@znicholls This should improve appending performance by 200x when dealing with data on the same timebase. Tested using the picked ScmRun's you provided from rcmip.

Appending ScmRun's with the same timebase was always reindexing