### PR TITLE
Metadata handling in unit conversion and groupby

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#75 <https://github.com/openscm/scmdata/pull/75>`_) Add test to ensure that :meth:`scmdata.ScmRun.groupby` cannot pick up the same timeseries twice even if metadata is changed by the function being applied
 - (`#125 <https://github.com/openscm/scmdata/pull/125>`_) Fix edge-case when filtering an empty :class:`scmdata.ScmRun`
 - (`#123 <https://github.com/openscm/scmdata/pull/123>`_) Add :class:`scmdata.database.ScmDatabase` to read/write data using multiple files. (closes `#103 <https://github.com/openscm/scmdata/issues/103>`_)
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -2288,8 +2288,7 @@ def test_convert_unit_multiple_units(
         res = tdf.convert_unit(target_unit)
         assert res.get_unique_meta("unit", no_duplicates=True) == target_unit
         npt.assert_allclose(
-            res.timeseries().sort_index().values,
-            tdf.timeseries().sort_index().values,
+            res.timeseries().sort_index().values, tdf.timeseries().sort_index().values,
         )
 
 


### PR DESCRIPTION
# Pull request

Fix problem where groupby can pick up the same timeseries twice if metadata is altered by any function which is subsequently applied (e.g. with `map`).

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable) (N/A)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable) (N/A)
- [x] Description in ``CHANGELOG.rst`` added

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <https://github.com/openscm/scmdata/pull/XX>`_) Added feature which does something
- (`#XX <https://github.com/openscm/scmdata/pull/XX>`_) Fixed bug identified in (`#YY <https://github.com/openscm/scmdata/issues/YY>`_)
```
