### PR TITLE
Change default value of check_ts_names argument 

### DIFF
--- a/src/scmdata/testing.py
+++ b/src/scmdata/testing.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pandas.testing as pdt
 
 
-def assert_scmdf_almost_equal(left, right, allow_unordered=False, check_ts_names=True):
+def assert_scmdf_almost_equal(left, right, allow_unordered=False, check_ts_names=False):
     """
     Check that left and right :obj:`ScmDataFrame` or :obj:`ScmRun` are equal.
 

--- a/tests/unit/test_groupby.py
+++ b/tests/unit/test_groupby.py
@@ -17,7 +17,7 @@ def test_groupby(test_scm_run, g):
 
     res = test_scm_run.groupby(*g).map(func)
 
-    assert_scmdf_almost_equal(res, test_scm_run, allow_unordered=True)
+    assert_scmdf_almost_equal(res, test_scm_run, allow_unordered=True, check_ts_names=True)
 
 
 def test_groupby_return_none(test_scm_run):

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -332,7 +332,7 @@ def test_init_self(test_iam_df, data_cls):
     a = data_cls(test_iam_df)
     b = data_cls(a)
 
-    assert_scmdf_almost_equal(a, b)
+    assert_scmdf_almost_equal(a, b, check_ts_names=True)
 
 
 def test_init_with_metadata(test_scm_run):
@@ -1123,7 +1123,7 @@ def test_append_exact_duplicates(test_scm_run):
 
     assert len(mock_warn_taking_average) == 1  # test message elsewhere
 
-    assert_scmdf_almost_equal(test_scm_run, other)
+    assert_scmdf_almost_equal(test_scm_run, other, check_ts_names=True)
 
 
 def test_append_duplicates(test_scm_run):


### PR DESCRIPTION

# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Example added (either to an existing notebook or as a new notebook, where applicable)
- [ ] Description in ``CHANGELOG.rst`` added

A quick search shows that a couple of lines need to be tweaked when the projects are updated to scmdata>0.7.0.

`find . -name "*.py" -not -path "*/venv/*" -exec grep -n assert_scmdf_almost_equal {} /dev/null \;`

```
./magicc-api/worker/dependencies/deps/scmdata/testing.py:10:def assert_scmdf_almost_equal(left, right, allow_unordered=False, check_ts_names=True):
./magicc/tests/sanity/test_read_output.py:17:from scmdata.testing import assert_scmdf_almost_equal
./magicc/tests/sanity/test_read_output.py:150:    assert_scmdf_almost_equal(ascii_out, v2_out)
./scmdata/src/scmdata/testing.py:10:def assert_scmdf_almost_equal(left, right, allow_unordered=False, check_ts_names=False):
./scmdata/tests/unit/test_run.py:18:from scmdata.testing import assert_scmdf_almost_equal
./scmdata/tests/unit/test_run.py:237:    assert_scmdf_almost_equal(df, b, check_ts_names=False)
./scmdata/tests/unit/test_run.py:243:    assert_scmdf_almost_equal(df, test_scm_datetime_run, check_ts_names=False)
./scmdata/tests/unit/test_run.py:300:    assert_scmdf_almost_equal(df, test_scm_df_mulitple, check_ts_names=False)
./scmdata/tests/unit/test_run.py:328:    assert_scmdf_almost_equal(a, b, check_ts_names=False)
./scmdata/tests/unit/test_run.py:335:    assert_scmdf_almost_equal(a, b, check_ts_names=True)
./scmdata/tests/unit/test_run.py:1126:    assert_scmdf_almost_equal(test_scm_run, other, check_ts_names=True)
./scmdata/tests/unit/test_groupby.py:3:from scmdata.testing import assert_scmdf_almost_equal
./scmdata/tests/unit/test_groupby.py:20:    assert_scmdf_almost_equal(res, test_scm_run, allow_unordered=True, check_ts_names=True)
./scmdata/tests/unit/test_ops.py:9:from scmdata.testing import assert_scmdf_almost_equal
./scmdata/tests/unit/test_ops.py:132:    assert_scmdf_almost_equal(res, exp, allow_unordered=True, check_ts_names=False)
./scmdata/tests/unit/test_ops.py:159:    assert_scmdf_almost_equal(res, exp, allow_unordered=True, check_ts_names=False)
./scmdata/tests/unit/test_ops.py:204:    assert_scmdf_almost_equal(res, exp, allow_unordered=True, check_ts_names=False)
./scmdata/tests/unit/test_ops.py:221:    assert_scmdf_almost_equal(res, exp, allow_unordered=True, check_ts_names=False)
./scmdata/tests/unit/test_netcdf.py:14:from scmdata.testing import assert_scmdf_almost_equal
./scmdata/tests/unit/test_netcdf.py:124:        assert_scmdf_almost_equal(scm_data, df, check_ts_names=False)
./scmdata/tests/unit/test_netcdf.py:159:        assert_scmdf_almost_equal(scm_data, df, check_ts_names=False)
./scmdata/tests/unit/test_netcdf.py:246:        assert_scmdf_almost_equal(scm_data, df, check_ts_names=False)
./scmdata/tests/unit/test_netcdf.py:270:        assert_scmdf_almost_equal(scm_data, df, check_ts_names=False)
./scmdata/build/lib/scmdata/testing.py:10:def assert_scmdf_almost_equal(left, right, allow_unordered=False, check_ts_names=True):
./pymagicc/tests/test_io.py:19:from scmdata.testing import assert_scmdf_almost_equal
./pymagicc/tests/test_io.py:3141:    assert_scmdf_almost_equal(
./pymagicc/tests/test_io.py:3814:    assert_scmdf_almost_equal(res, writing_base_mag, check_ts_names=False)

```