### PR TITLE
Fix non-unique metadata in ScmRun.timeseries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#96 <https://github.com/openscm/scmdata/pull/96>`_) Fix non-unique timeseries metadata checks for :meth:`ScmRun.timeseries`
 - (`#100 <https://github.com/openscm/scmdata/pull/100>`_) When initialising :obj:`ScmRun` from file, make the default be to read with :func:`pd.read_csv`. This means we now initialising reading from gzipped CSV files.
 - (`#99 <https://github.com/openscm/scmdata/pull/99>`_) Hotfix failing notebook test
 - (`#94 <https://github.com/openscm/scmdata/pull/94>`_) Fix edge-case issue with drop_meta (closes `#92 <https://github.com/openscm/scmdata/issues/92>`_)

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -2419,6 +2419,15 @@ def test_timeseries_time_axis_junk_error(test_scm_run):
         test_scm_run.timeseries(time_axis="junk")
 
 
+def test_timeseries_check_duplicated(test_scm_run):
+    with pytest.raises(NonUniqueMetadataError):
+        test_scm_run.timeseries(meta=["region", "unit"], check_duplicated=True)
+
+    # Default behaviour
+    with pytest.raises(NonUniqueMetadataError):
+        test_scm_run.timeseries(meta=["region", "unit"])
+
+
 def test_long_data_time_axis_junk_error(test_scm_run):
     error_msg = re.escape("time_axis = 'junk")
     with pytest.raises(NotImplementedError, match=error_msg):


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added
