### PR TITLE
Workaround lack of wheel for cftime on windows with Python 3.6

### DIFF
--- a/.github/workflows/test-pypi-install.yml
+++ b/.github/workflows/test-pypi-install.yml
@@ -1,8 +1,8 @@
 name: Test PyPI install
-on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '0 0 * * 3'
+on: push
+  # schedule:
+  #   # * is a special character in YAML so you have to quote this string
+  #   - cron:  '0 0 * * 3'
 
 jobs:
   test-installation:
@@ -18,6 +18,13 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    # no windows wheel for Python 3.6 cftime 1.3.1
+    # https://github.com/Unidata/cftime/issues/224
+    - name: Install cftime 1.3.0 (${{ runner.os }})
+      if: startsWith(runner.os, 'Windows') && endsWith(matrix.python-version, '3.6')
+      run: |
+        pip install --upgrade --user pip wheel
+        pip install cftime==1.3.0
     - name: Install package
     # avoid installing pre-releases of non-scmdata packages
       run: |

--- a/.github/workflows/test-pypi-install.yml
+++ b/.github/workflows/test-pypi-install.yml
@@ -1,8 +1,8 @@
 name: Test PyPI install
-on: push
-  # schedule:
-  #   # * is a special character in YAML so you have to quote this string
-  #   - cron:  '0 0 * * 3'
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 0 * * 3'
 
 jobs:
   test-installation:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#140 <https://github.com/openscm/scmdata/pull/140>`_) Add workaround for installing scmdata with Python 3.6 on windows to handle lack of cftime 1.3.1 wheel
 - (`#138 <https://github.com/openscm/scmdata/pull/138>`_) Add :meth:`ScmRun.quantiles_over`
 - (`#137 <https://github.com/openscm/scmdata/pull/137>`_) Fix :meth:`scmdata.ScmRun.to_csv` so that writing and reading is circular (i.e. you end up where you started if you write a file and then read it straight back into a new :obj:`scmdata.ScmRun` instance)
 


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added (N/A)
- [x] Documentation added (where applicable) (N/A)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable) (N/A)
- [x] Description in ``CHANGELOG.rst`` added

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <https://github.com/openscm/scmdata/pull/XX>`_) Added feature which does something
- (`#XX <https://github.com/openscm/scmdata/pull/XX>`_) Fixed bug identified in (`#YY <https://github.com/openscm/scmdata/issues/YY>`_)
```
