### PR TITLE
BUG: Fix plumeplot style if dashes not supplied

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 master
 ------
 
+- (`#144 <https://github.com/openscm/scmdata/pull/144>`_) Fix :meth:`ScmRun.plumeplot` style handling (previously, if ``dashes`` was not supplied each line would be a different style even if all the lines had the same value for ``style_var``)
+
 v0.9.0
 ------
 

--- a/src/scmdata/plotting.py
+++ b/src/scmdata/plotting.py
@@ -272,7 +272,9 @@ def plumeplot(  # pragma: no cover
                             )
                             raise KeyError(error_msg) from exc
                     else:
-                        _dashes[style_value] = next(linestyle_cycler)
+                        if style_value not in _dashes:
+                            _dashes[style_value] = next(linestyle_cycler)
+
                         pkwargs["linestyle"] = _dashes[style_value]
 
                     if isinstance(q[0], str):

--- a/tests/integration/test_plotting_integration.py
+++ b/tests/integration/test_plotting_integration.py
@@ -279,8 +279,8 @@ def test_plumeplot_no_dashes_single_dash_style(plumeplot_scmrun):
 
     assert legend_items[-1].get_linestyle() == "-"
 
-    for l in ax.lines:
-        assert l.get_linestyle() == "-"
+    for line in ax.lines:
+        assert line.get_linestyle() == "-"
 
 
 # sensible error if missing style etc.

--- a/tests/integration/test_plotting_integration.py
+++ b/tests/integration/test_plotting_integration.py
@@ -273,11 +273,9 @@ def test_plumeplot_values(plumeplot_scmrun, quantiles_plumes, time_axis, linewid
 def test_plumeplot_no_dashes_single_dash_style(plumeplot_scmrun):
     # if there's only a single variable and it is used for style, without
     # specifying dashes then all the lines should come out solid
-    ax, legend_items = (
-        plumeplot_scmrun
-        .filter(variable="Surface Air Temperature Change")
-        .plumeplot(style_var="variable")
-    )
+    ax, legend_items = plumeplot_scmrun.filter(
+        variable="Surface Air Temperature Change"
+    ).plumeplot(style_var="variable")
 
     assert legend_items[-1].get_linestyle() == "-"
 

--- a/tests/integration/test_plotting_integration.py
+++ b/tests/integration/test_plotting_integration.py
@@ -270,6 +270,21 @@ def test_plumeplot_values(plumeplot_scmrun, quantiles_plumes, time_axis, linewid
     assert all([_is_in_calls(c, mock_ax.plot.call_args_list) for c in plot_calls])
 
 
+def test_plumeplot_no_dashes_single_dash_style(plumeplot_scmrun):
+    # if there's only a single variable and it is used for style, without
+    # specifying dashes then all the lines should come out solid
+    ax, legend_items = (
+        plumeplot_scmrun
+        .filter(variable="Surface Air Temperature Change")
+        .plumeplot(style_var="variable")
+    )
+
+    assert legend_items[-1].get_linestyle() == "-"
+
+    for l in ax.lines:
+        assert l.get_linestyle() == "-"
+
+
 # sensible error if missing style etc.
 def test_error_missing_palette(plumeplot_scmrun):
     # extra definitions are fine


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable) (N/A)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable) (N/A)
- [] Description in ``CHANGELOG.rst`` added

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <https://github.com/openscm/scmdata/pull/XX>`_) Added feature which does something
- (`#XX <https://github.com/openscm/scmdata/pull/XX>`_) Fixed bug identified in (`#YY <https://github.com/openscm/scmdata/issues/YY>`_)
```
