### PR TITLE
Add option to disable progress bars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#157 <https://github.com/openscm/scmdata/pull/157>`_) Add ``disable_tqdm`` parameter to :meth:`scmdata.database.ScmDatabase.load` and :meth:`scmdata.database.ScmDatabase.save` to disable displaying progress bars
 - (`#156 <https://github.com/openscm/scmdata/pull/156>`_) Fix :mod:`pandas` and :mod:`xarray` documentation links
 - (`#155 <https://github.com/openscm/scmdata/pull/155>`_) Simplify flake8 configuration
 

--- a/src/scmdata/database.py
+++ b/src/scmdata/database.py
@@ -113,7 +113,7 @@ class ScmDatabase:
 
         return "".join(safe_char(c) for c in inp)
 
-    def save(self, scmrun):
+    def save(self, scmrun, disable_tqdm=False):
         """
         Save data to the database
 
@@ -130,9 +130,14 @@ class ScmDatabase:
 
             The timeseries in this run should have valid metadata for each
             of the columns specified in ``levels``.
+        disable_tqdm: bool
+            If True, do not show the progress bar
         """
         for r in tqdman.tqdm(
-            scmrun.groupby(self.levels), leave=False, desc="Saving to database",
+            scmrun.groupby(self.levels),
+            leave=False,
+            desc="Saving to database",
+            disable=disable_tqdm,
         ):
             self._save_to_database_single_file(r)
 
@@ -192,12 +197,14 @@ class ScmDatabase:
         dimensions = nunique_meta_vals[nunique_meta_vals > 1].index.tolist()
         scmrun.to_nc(out_file, dimensions=dimensions)
 
-    def load(self, **filters):
+    def load(self, disable_tqdm=False, **filters):
         """
         Load data from the database
 
         Parameters
         ----------
+        disable_tqdm: bool
+            If True, do not show the progress bar
         filters: dict of str : [str, list[str]]
             Filters for the data to load.
 
@@ -250,7 +257,9 @@ class ScmDatabase:
         return run_append(
             [
                 ScmRun.from_nc(f)
-                for f in tqdman.tqdm(load_files, desc="Loading files", leave=False)
+                for f in tqdman.tqdm(
+                    load_files, desc="Loading files", leave=False, disable=disable_tqdm
+                )
             ]
         )
 


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Documentation added (where applicable)
- [x] Description in ``CHANGELOG.rst`` added

An easy one. Since tqdm is only used in two places I don't think it is worth implementing something like `openscm_runner.progress`