### PR TITLE
Check transpose

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#168 <https://github.com/openscm/scmdata/pull/168>`_) Improve the error messages when checking that :class:`scmdata.ScmRun` objects are similar
 - (`#165 <https://github.com/openscm/scmdata/pull/165>`_) Add :func:`scmdata.processing.calculate_crossing_times`
 - (`#164 <https://github.com/openscm/scmdata/pull/164>`_) Added :meth:`scmdata.ScmRun.append_timewise` to allow appending of data along the time axis with broadcasting along multiple meta dimensions
 - (`#164 <https://github.com/openscm/scmdata/pull/164>`_) Sort time axis internally (ensures that :meth:`scmdata.ScmRun.__repr__` renders properly)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 master
 ------
 
-- (`#168 <https://github.com/openscm/scmdata/pull/168>`_) Improve the error messages when checking that :class:`scmdata.ScmRun` objects are similar
+- (`#168 <https://github.com/openscm/scmdata/pull/168>`_) Improve the error messages when checking that :class:`scmdata.ScmRun` objects are identical
 - (`#165 <https://github.com/openscm/scmdata/pull/165>`_) Add :func:`scmdata.processing.calculate_crossing_times`
 - (`#164 <https://github.com/openscm/scmdata/pull/164>`_) Added :meth:`scmdata.ScmRun.append_timewise` to allow appending of data along the time axis with broadcasting along multiple meta dimensions
 - (`#164 <https://github.com/openscm/scmdata/pull/164>`_) Sort time axis internally (ensures that :meth:`scmdata.ScmRun.__repr__` renders properly)

--- a/src/scmdata/testing.py
+++ b/src/scmdata/testing.py
@@ -22,7 +22,7 @@ def _assert_frame_equal(left, right, **kwargs):
         kwargs.pop("rtol", None)
         kwargs.pop("atol", None)
 
-    pdt.assert_frame_equal(left, right, **kwargs)
+    pdt.assert_frame_equal(left.T, right.T, **kwargs)
 
 
 def assert_scmdf_almost_equal(

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,0 +1,20 @@
+import pytest
+
+import scmdata.testing
+
+
+def test_almost_equal_message(scm_run):
+    other = scmdata.run_append(
+        [
+            scm_run.filter(scenario="a_scenario") * 2,
+            scm_run.filter(scenario="a_scenario2"),
+        ]
+    )
+
+    # matches the first item even though multiple are wrong
+    msg = r"\'a_scenario\', \'EJ/yr\', \'Primary Energy\'"
+
+    with pytest.raises(AssertionError, match=msg):
+        scmdata.testing.assert_scmdf_almost_equal(
+            scm_run, other, allow_unordered=True, check_ts_names=False
+        )


### PR DESCRIPTION
# Pull request

Improves the error message when checking for identical timeseries as it tells you which timeseries failed

New message:
```
E   AssertionError: DataFrame.iloc[:, 36] (column name="('IMAGE', 'World', 'ssp119', 'infilled', 'kt HFC227ea/yr', 'Emissions|HFC227ea')") are different
E   
E   DataFrame.iloc[:, 36] (column name="('IMAGE', 'World', 'ssp119', 'infilled', 'kt HFC227ea/yr', 'Emissions|HFC227ea')") values are different (100.0 %)
E   [index]: [2015-01-01T00:00:00.000000000, 2016-01-01T00:00:00.000000000, 2017-01-01T00:00:00.000000000, 2018-01-01T00:00:00.000000000, 2019-01-01T00:00:00.000000000]
E   [left]:  [8.8482, 8.022087280625891, 7.19371123873295, 6.367598519358841, 5.5414857999847325]
E   [right]: [7.3266, 7.981129353778751, 8.637451938663746, 9.291981292442497, 9.946510646221249]
```

Old:
```
E   AssertionError: DataFrame.iloc[:, 0] (column name="2015-01-01 00:00:00") are different
E   
E   DataFrame.iloc[:, 0] (column name="2015-01-01 00:00:00") values are different (1.92308 %)
E   [index]: [(IMAGE, World, ssp119, infilled, Mt BC/yr, Emissions|BC), (IMAGE, World, ssp119, infilled, Mt CH4/yr, Emissions|CH4), (IMAGE, World, ssp119, infilled, Mt CO/yr, Emissions|CO), (IMAGE, World, ssp119, infilled, Mt CO2/yr, Emissions|CO2|MAGICC AFOLU), (IMAGE, World, ssp119, infilled, Mt CO2/yr, Emissions|CO2|MAGICC Fossil and Industrial), (IMAGE, World, ssp119, infilled, Mt NH3/yr, Emissions|NH3), (IMAGE, World, ssp119, infilled, Mt NOx/yr, Emissions|NOx), (IMAGE, World, ssp119, infilled, Mt OC/yr, Emissions|OC), (IMAGE, World, ssp119, infilled, Mt SO2/yr, Emissions|Sulfur), (IMAGE, World, ssp119, infilled, Mt VOC/yr, Emissions|VOC), (IMAGE, World, ssp119, infilled, kt C2F6/yr, Emissions|C2F6), (IMAGE, World, ssp119, infilled, kt C3F8/yr, Emissions|C3F8), (IMAGE, World, ssp119, infilled, kt C4F10/yr, Emissions|C4F10), (IMAGE, World, ssp119, infilled, kt C5F12/yr, Emissions|C5F12), (IMAGE, World, ssp119, infilled, kt C6F14/yr, Emissions|C6F14), (IMAGE, World, ssp119, infilled, kt C7F16/yr, Emissions|C7F16), (IMAGE, World, ssp119, infilled, kt C8F18/yr, Emissions|C8F18), (IMAGE, World, ssp119, infilled, kt CCl4/yr, Emissions|CCl4), (IMAGE, World, ssp119, infilled, kt CF4/yr, Emissions|CF4), (IMAGE, World, ssp119, infilled, kt CFC11/yr, Emissions|CFC11), (IMAGE, World, ssp119, infilled, kt CFC113/yr, Emissions|CFC113), (IMAGE, World, ssp119, infilled, kt CFC114/yr, Emissions|CFC114), (IMAGE, World, ssp119, infilled, kt CFC115/yr, Emissions|CFC115), (IMAGE, World, ssp119, infilled, kt CFC12/yr, Emissions|CFC12), (IMAGE, World, ssp119, infilled, kt CH2Cl2/yr, Emissions|CH2Cl2), (IMAGE, World, ssp119, infilled, kt CH3Br/yr, Emissions|CH3Br), (IMAGE, World, ssp119, infilled, kt CH3CCl3/yr, Emissions|CH3CCl3), (IMAGE, World, ssp119, infilled, kt CH3Cl/yr, Emissions|CH3Cl), (IMAGE, World, ssp119, infilled, kt CHCl3/yr, Emissions|CHCl3), (IMAGE, World, ssp119, infilled, kt HCFC141b/yr, Emissions|HCFC141b), (IMAGE, World, ssp119, infilled, kt HCFC142b/yr, Emissions|HCFC142b), (IMAGE, World, ssp119, infilled, kt HCFC22/yr, Emissions|HCFC22), (IMAGE, World, ssp119, infilled, kt HFC125/yr, Emissions|HFC125), (IMAGE, World, ssp119, infilled, kt HFC134a/yr, Emissions|HFC134a), (IMAGE, World, ssp119, infilled, kt HFC143a/yr, Emissions|HFC143a), (IMAGE, World, ssp119, infilled, kt HFC152a/yr, Emissions|HFC152a), (IMAGE, World, ssp119, infilled, kt HFC227ea/yr, Emissions|HFC227ea), (IMAGE, World, ssp119, infilled, kt HFC23/yr, Emissions|HFC23), (IMAGE, World, ssp119, infilled, kt HFC236fa/yr, Emissions|HFC236fa), (IMAGE, World, ssp119, infilled, kt HFC245fa/yr, Emissions|HFC245fa), (IMAGE, World, ssp119, infilled, kt HFC32/yr, Emissions|HFC32), (IMAGE, World, ssp119, infilled, kt HFC365mfc/yr, Emissions|HFC365mfc), (IMAGE, World, ssp119, infilled, kt HFC4310mee/yr, Emissions|HFC4310mee), (IMAGE, World, ssp119, infilled, kt Halon1202/yr, Emissions|Halon1202), (IMAGE, World, ssp119, infilled, kt Halon1211/yr, Emissions|Halon1211), (IMAGE, World, ssp119, infilled, kt Halon1301/yr, Emissions|Halon1301), (IMAGE, World, ssp119, infilled, kt Halon2402/yr, Emissions|Halon2402), (IMAGE, World, ssp119, infilled, kt N2O/yr, Emissions|N2O), (IMAGE, World, ssp119, infilled, kt NF3/yr, Emissions|NF3), (IMAGE, World, ssp119, infilled, kt SF6/yr, Emissions|SF6), (IMAGE, World, ssp119, infilled, kt SO2F2/yr, Emissions|SO2F2), (IMAGE, World, ssp119, infilled, kt cC4F8/yr, Emissions|cC4F8)]
E   [left]:  [9.72742, 388.073, 934.35, 3517.44, 35635.3, 65.2797, 155.52, 34.746, 100.771, 227.245, 1.57, 0.4478, 0.0994, 0.0435, 0.35, 0.2338, 0.1014, 47.5476, 10.8699, 43.5734, 0.8742000000000001, 1.6696, 1.6714, 14.6096, 1267.98, 133.823, 0.0, 5404.81, 459.646, 59.82, 22.47, 358.881, 78.7906, 201.953, 32.381, 55.8814, 8.8482, 14.4857, 0.2604, 11.7285, 38.5792, 4.6492, 1.1516, 0.0, 3.2933, 1.3378, 0.3481, 10900.0, 1.3581, 8.02, 2.5317, 1.2672]
E   [right]: [9.72742, 388.073, 934.35, 3517.44, 35635.3, 65.2797, 155.52, 34.746, 100.771, 227.245, 1.57, 0.4478, 0.0994, 0.0435, 0.35, 0.2338, 0.1014, 47.5476, 10.8699, 43.5734, 0.8742000000000001, 1.6696, 1.6714, 14.6096, 1267.98, 133.823, 0.0, 5404.81, 459.646, 59.82, 22.47, 358.881, 78.7906, 201.953, 32.381, 55.8814, 7.3266, 14.4857, 0.2604, 11.7285, 38.5792, 4.6492, 1.1516, 0.0, 3.2933, 1.3378, 0.3481, 10900.0, 1.3581, 8.02, 2.5317, 1.2672]
```

The one downside is that the `DataFrame.iloc[:, 36]` message does not actually map to `inp.timeseries().iloc[:, 36]`, but rather `inp.timeseries().iloc[36]`. I don' think adding the extra effort to rewrite this error message is worth it given it's primary usage is internal


Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added