### PR TITLE
Add round function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#184 <https://github.com/openscm/scmdata/pull/184>`_) Add :func:`scmdata.run.ScmRun.round`
 - (`#182 <https://github.com/openscm/scmdata/pull/182>`_) Updated incorrect `conda` install instructions
 
 v0.13.1

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -2200,6 +2200,48 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
 
             return type(self)(data, index=index, columns=meta)
 
+    def round(self, decimals=3, inplace=False):
+        """
+        Round data to a given number of decimal places.
+
+        For values exactly halfway between rounded decimal values, NumPy rounds
+        to the nearest even value. Thus 1.5 and 2.5 round to 2.0, -0.5 and 0.5
+        round to 0.0, etc.
+
+        Parameters
+        ----------
+        decimals : int
+            Number of decimal places to round each value to.
+
+        inplace : bool
+            If True, apply the conversion inplace and return None
+
+        Returns
+        -------
+        :class:`ScmRun <scmdata.run.ScmRun>`
+            If :obj:`inplace` is not ``False``, a new :class:`ScmRun <scmdata.run.ScmRun>` instance
+            with the rounded values.
+
+        """
+        if inplace:
+            ret = self
+        else:
+            ret = self.copy()
+
+        # Check if any values are smaller than half the smallest step
+        # They may be rounded down to zero
+        min_value = ret._df.abs().min().min()
+        if min_value <= 0.5 * 10 ** -decimals:
+            warnings.warn(
+                "There are small values which may be truncated during rounding. Either increase the number"
+                "of decimals or convert the units of the timeseries so that the quantities are larger."
+            )
+
+        ret._df = ret._df.round(decimals)
+
+        if not inplace:
+            return ret
+
 
 def _merge_metadata(metadata):
     res = metadata[0].copy()

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -299,6 +299,13 @@ def _from_ts(
     return df, meta
 
 
+def _get_target(run, inplace):
+    if inplace:
+        return run
+    else:
+        return run.copy()
+
+
 class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
     """
     Base class of a data container for timeseries data
@@ -745,10 +752,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         KeyError
             If any of the columns do not exist in the meta :class:`DataFrame`
         """
-        if inplace:
-            ret = self
-        else:
-            ret = self.copy()
+        ret = _get_target(self, inplace)
 
         if isinstance(columns, str):
             columns = [columns]
@@ -1881,11 +1885,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
             ``"unit_context"`` is already included in ``self``'s :meth:`meta_attributes`
             and it does not match ``context`` for the variables to be converted.
         """
-        # pylint: disable=protected-access
-        if inplace:
-            ret = self
-        else:
-            ret = self.copy()
+        ret = _get_target(self, inplace)
 
         to_convert_filtered = ret.filter(**kwargs, log_if_empty=False)
         to_not_convert_filtered = ret.filter(**kwargs, keep=False, log_if_empty=False)
@@ -2223,10 +2223,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
             with the rounded values.
 
         """
-        if inplace:
-            ret = self
-        else:
-            ret = self.copy()
+        ret = _get_target(self, inplace)
 
         # Check if any values are smaller than half the smallest step
         # They may be rounded down to zero

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -3485,32 +3485,26 @@ def test_time_as_cftime(scm_run, output_cls):
 def test_round():
     # There are some quirks with the rounding due to the algo used
 
-    run = ScmRun(
-        data=np.array([[3.6565, 5.51, 5.55, 5.45, 1]]).T,
-        index=[2000, 2025, 2030, 2035, 2040],
-        columns={
+    def compare(inp, exp, decimals=1):
+        cols = {
             "model": "model",
             "scenario": "scenario",
             "variable": "variable",
             "region": "region",
             "unit": "unit",
-        },
-    )
+        }
+        index = [2000, 2025, 2030, 2035, 2040]
+        run = ScmRun(data=np.array([inp]).T, index=index, columns=cols,)
 
-    res = run.round(1)
+        res = run.round(decimals)
 
-    exp = ScmRun(
-        data=np.array([[3.7, 5.5, 5.6, 5.4, 1.0]]).T,
-        index=[2000, 2025, 2030, 2035, 2040],
-        columns={
-            "model": "model",
-            "scenario": "scenario",
-            "variable": "variable",
-            "region": "region",
-            "unit": "unit",
-        },
-    )
-    assert_scmdf_almost_equal(res, exp)
+        exp = ScmRun(data=np.array([exp]).T, index=index, columns=cols,)
+        assert_scmdf_almost_equal(res, exp)
+
+    compare([3.6565, 5.51, 5.55, 5.45, 1], [3.7, 5.5, 5.6, 5.4, 1.0])
+    compare([-3.6565, -5.51, -5.55, -5.45, -1], [-3.7, -5.5, -5.6, -5.4, -1.0])
+    compare([-3.6565, -5.51, -5.55, -5.45, -1], [-4, -6, -6, -5.0, -1.0], decimals=0)
+    compare([3.6565, 5.51, 5.55, 5.45, 1], [3.6565, 5.51, 5.55, 5.45, 1.0], decimals=5)
 
 
 def test_round_warns_small():
@@ -3531,15 +3525,15 @@ def test_round_warns_small():
     with pytest.warns(UserWarning, match=match):
         res = run.round(1)
 
-        exp = ScmRun(
-            data=np.array([[3.7, 5.5, 5.6, 1.0, 0]]).T,
-            index=[2000, 2025, 2030, 2035, 2040],
-            columns={
-                "model": "model",
-                "scenario": "scenario",
-                "variable": "variable",
-                "region": "region",
-                "unit": "unit",
-            },
-        )
-        assert_scmdf_almost_equal(res, exp)
+    exp = ScmRun(
+        data=np.array([[3.7, 5.5, 5.6, 1.0, 0]]).T,
+        index=[2000, 2025, 2030, 2035, 2040],
+        columns={
+            "model": "model",
+            "scenario": "scenario",
+            "variable": "variable",
+            "region": "region",
+            "unit": "unit",
+        },
+    )
+    assert_scmdf_almost_equal(res, exp)

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -3480,3 +3480,66 @@ def test_time_as_cftime(scm_run, output_cls):
         assert all([isinstance(v, cftime.DatetimeGregorian) for v in res])
     else:
         assert all([isinstance(v, output_cls) for v in res])
+
+
+def test_round():
+    # There are some quirks with the rounding due to the algo used
+
+    run = ScmRun(
+        data=np.array([[3.6565, 5.51, 5.55, 5.45, 1]]).T,
+        index=[2000, 2025, 2030, 2035, 2040],
+        columns={
+            "model": "model",
+            "scenario": "scenario",
+            "variable": "variable",
+            "region": "region",
+            "unit": "unit",
+        },
+    )
+
+    res = run.round(1)
+
+    exp = ScmRun(
+        data=np.array([[3.7, 5.5, 5.6, 5.4, 1.0]]).T,
+        index=[2000, 2025, 2030, 2035, 2040],
+        columns={
+            "model": "model",
+            "scenario": "scenario",
+            "variable": "variable",
+            "region": "region",
+            "unit": "unit",
+        },
+    )
+    assert_scmdf_almost_equal(res, exp)
+
+
+def test_round_warns_small():
+    run = ScmRun(
+        data=np.array([[3.6565, 5.51, 5.55, 1, 2.34e-2]]).T,
+        index=[2000, 2025, 2030, 2035, 2040],
+        columns={
+            "model": "model",
+            "scenario": "scenario",
+            "variable": "variable",
+            "region": "region",
+            "unit": "unit",
+        },
+    )
+
+    match = "There are small values which may be truncated during rounding"
+
+    with pytest.warns(UserWarning, match=match):
+        res = run.round(1)
+
+        exp = ScmRun(
+            data=np.array([[3.7, 5.5, 5.6, 1.0, 0]]).T,
+            index=[2000, 2025, 2030, 2035, 2040],
+            columns={
+                "model": "model",
+                "scenario": "scenario",
+                "variable": "variable",
+                "region": "region",
+                "unit": "unit",
+            },
+        )
+        assert_scmdf_almost_equal(res, exp)


### PR DESCRIPTION
This is a handy helper which I sometimes do before writing a CSV. I usually convert to a DataFrame, call round and then write, but it would be nice to avoid the conversion 

# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added
