### PR TITLE
Constant extrapolation special case

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#190 <https://github.com/openscm/scmdata/pull/190>`_) Add special case for extrapolating timeseries containing a single timestep using ``constant`` extrapolation. Moved :attr:`scmdata.errors.InsufficientDataError` from :mod:`scmdata.time` to :mod:`scmdata.errors`
 - (`#186 <https://github.com/openscm/scmdata/pull/186>`_ and `#187 <https://github.com/openscm/scmdata/pull/187>`_) Fix the handling of non-alphanumeric characters in filenames on Windows for :class:`scmdata.database.ScmDatabase`. ``*`` values are no longer included in :class:`scmdata.database.ScmDatabase` filenames
 - (`#186 <https://github.com/openscm/scmdata/pull/186>`_ Move to ``pyproject.toml`` for setup etc.
 - (`#185 <https://github.com/openscm/scmdata/pull/185>`_) Allow :class:`scmdata.run.ScmRun` to read remote files by providing a URL to the constructor

--- a/notebooks/time-operations.ipynb
+++ b/notebooks/time-operations.ipynb
@@ -34,6 +34,7 @@
     "import traceback\n",
     "\n",
     "import scmdata.time\n",
+    "import scmdata.errors\n",
     "from scmdata import ScmRun, run_append\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
@@ -2789,7 +2790,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "scmdata.time.InsufficientDataError: Target time points are outside the source time points, use an extrapolation type other than None\n"
+      "scmdata.errors.InsufficientDataError: Target time points are outside the source time points, use an extrapolation type other than None\n"
      ]
     }
    ],
@@ -2801,6 +2802,272 @@
     "    )\n",
     "except scmdata.time.InsufficientDataError:\n",
     "    traceback.print_exc(limit=0, chain=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generally the `interpolate` requires at minimum 3 times in order to perform any interpolation/extrapolation, otherwise an `InsufficientDataError` is raised. There is a special case where `constant` extrapolation can be used on a single time-step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>1700-07-01 00:00:00</th>\n",
+       "      <th>1701-07-01 00:00:00</th>\n",
+       "      <th>1702-07-01 00:00:00</th>\n",
+       "      <th>1703-07-01 00:00:00</th>\n",
+       "      <th>1704-07-01 00:00:00</th>\n",
+       "      <th>1705-07-01 00:00:00</th>\n",
+       "      <th>1706-07-01 00:00:00</th>\n",
+       "      <th>...</th>\n",
+       "      <th>2544-07-01 00:00:00</th>\n",
+       "      <th>2545-07-01 00:00:00</th>\n",
+       "      <th>2546-07-01 00:00:00</th>\n",
+       "      <th>2547-07-01 00:00:00</th>\n",
+       "      <th>2548-07-01 00:00:00</th>\n",
+       "      <th>2549-07-01 00:00:00</th>\n",
+       "      <th>2550-07-01 00:00:00</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>model</th>\n",
+       "      <th>region</th>\n",
+       "      <th>scenario</th>\n",
+       "      <th>time operation</th>\n",
+       "      <th>unit</th>\n",
+       "      <th>variable</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">IMAGE</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">World</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">RCP26</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">extrapolated constant</th>\n",
+       "      <th>Mt BC / yr</th>\n",
+       "      <th>Emissions|BC</th>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>...</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "      <td>7.8048</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>kt C2F6 / yr</th>\n",
+       "      <th>Emissions|C2F6</th>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "      <td>2.3749</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>kt C6F14 / yr</th>\n",
+       "      <th>Emissions|C6F14</th>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "      <td>0.4624</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>kt CCl4 / yr</th>\n",
+       "      <th>Emissions|CCl4</th>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>...</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "      <td>74.1320</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>kt CF4 / yr</th>\n",
+       "      <th>Emissions|CF4</th>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>...</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "      <td>12.0001</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 851 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "time                                                                       1700-07-01 00:00:00  1701-07-01 00:00:00  \\\n",
+       "model region scenario time operation        unit          variable                                                    \n",
+       "IMAGE World  RCP26    extrapolated constant Mt BC / yr    Emissions|BC                  7.8048               7.8048   \n",
+       "                                            kt C2F6 / yr  Emissions|C2F6                2.3749               2.3749   \n",
+       "                                            kt C6F14 / yr Emissions|C6F14               0.4624               0.4624   \n",
+       "                                            kt CCl4 / yr  Emissions|CCl4               74.1320              74.1320   \n",
+       "                                            kt CF4 / yr   Emissions|CF4                12.0001              12.0001   \n",
+       "\n",
+       "time                                                                       1702-07-01 00:00:00  1703-07-01 00:00:00  \\\n",
+       "model region scenario time operation        unit          variable                                                    \n",
+       "IMAGE World  RCP26    extrapolated constant Mt BC / yr    Emissions|BC                  7.8048               7.8048   \n",
+       "                                            kt C2F6 / yr  Emissions|C2F6                2.3749               2.3749   \n",
+       "                                            kt C6F14 / yr Emissions|C6F14               0.4624               0.4624   \n",
+       "                                            kt CCl4 / yr  Emissions|CCl4               74.1320              74.1320   \n",
+       "                                            kt CF4 / yr   Emissions|CF4                12.0001              12.0001   \n",
+       "\n",
+       "time                                                                       1704-07-01 00:00:00  1705-07-01 00:00:00  \\\n",
+       "model region scenario time operation        unit          variable                                                    \n",
+       "IMAGE World  RCP26    extrapolated constant Mt BC / yr    Emissions|BC                  7.8048               7.8048   \n",
+       "                                            kt C2F6 / yr  Emissions|C2F6                2.3749               2.3749   \n",
+       "                                            kt C6F14 / yr Emissions|C6F14               0.4624               0.4624   \n",
+       "                                            kt CCl4 / yr  Emissions|CCl4               74.1320              74.1320   \n",
+       "                                            kt CF4 / yr   Emissions|CF4                12.0001              12.0001   \n",
+       "\n",
+       "time                                                                       1706-07-01 00:00:00  ...  \\\n",
+       "model region scenario time operation        unit          variable                              ...   \n",
+       "IMAGE World  RCP26    extrapolated constant Mt BC / yr    Emissions|BC                  7.8048  ...   \n",
+       "                                            kt C2F6 / yr  Emissions|C2F6                2.3749  ...   \n",
+       "                                            kt C6F14 / yr Emissions|C6F14               0.4624  ...   \n",
+       "                                            kt CCl4 / yr  Emissions|CCl4               74.1320  ...   \n",
+       "                                            kt CF4 / yr   Emissions|CF4                12.0001  ...   \n",
+       "\n",
+       "time                                                                       2544-07-01 00:00:00  2545-07-01 00:00:00  \\\n",
+       "model region scenario time operation        unit          variable                                                    \n",
+       "IMAGE World  RCP26    extrapolated constant Mt BC / yr    Emissions|BC                  7.8048               7.8048   \n",
+       "                                            kt C2F6 / yr  Emissions|C2F6                2.3749               2.3749   \n",
+       "                                            kt C6F14 / yr Emissions|C6F14               0.4624               0.4624   \n",
+       "                                            kt CCl4 / yr  Emissions|CCl4               74.1320              74.1320   \n",
+       "                                            kt CF4 / yr   Emissions|CF4                12.0001              12.0001   \n",
+       "\n",
+       "time                                                                       2546-07-01 00:00:00  2547-07-01 00:00:00  \\\n",
+       "model region scenario time operation        unit          variable                                                    \n",
+       "IMAGE World  RCP26    extrapolated constant Mt BC / yr    Emissions|BC                  7.8048               7.8048   \n",
+       "                                            kt C2F6 / yr  Emissions|C2F6                2.3749               2.3749   \n",
+       "                                            kt C6F14 / yr Emissions|C6F14               0.4624               0.4624   \n",
+       "                                            kt CCl4 / yr  Emissions|CCl4               74.1320              74.1320   \n",
+       "                                            kt CF4 / yr   Emissions|CF4                12.0001              12.0001   \n",
+       "\n",
+       "time                                                                       2548-07-01 00:00:00  2549-07-01 00:00:00  \\\n",
+       "model region scenario time operation        unit          variable                                                    \n",
+       "IMAGE World  RCP26    extrapolated constant Mt BC / yr    Emissions|BC                  7.8048               7.8048   \n",
+       "                                            kt C2F6 / yr  Emissions|C2F6                2.3749               2.3749   \n",
+       "                                            kt C6F14 / yr Emissions|C6F14               0.4624               0.4624   \n",
+       "                                            kt CCl4 / yr  Emissions|CCl4               74.1320              74.1320   \n",
+       "                                            kt CF4 / yr   Emissions|CF4                12.0001              12.0001   \n",
+       "\n",
+       "time                                                                       2550-07-01 00:00:00  \n",
+       "model region scenario time operation        unit          variable                              \n",
+       "IMAGE World  RCP26    extrapolated constant Mt BC / yr    Emissions|BC                  7.8048  \n",
+       "                                            kt C2F6 / yr  Emissions|C2F6                2.3749  \n",
+       "                                            kt C6F14 / yr Emissions|C6F14               0.4624  \n",
+       "                                            kt CCl4 / yr  Emissions|CCl4               74.1320  \n",
+       "                                            kt CF4 / yr   Emissions|CF4                12.0001  \n",
+       "\n",
+       "[5 rows x 851 columns]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rcp26_yr2000 = rcp26.filter(year=2000)\n",
+    "rcp26_extrap_const_single = rcp26_yr2000.interpolate(\n",
+    "    target_times=sorted([dt.datetime(v, 7, 1) for v in range(1700, 2551)]),\n",
+    "    extrapolation_type=\"constant\",\n",
+    ")\n",
+    "rcp26_extrap_const_single[\"time operation\"] = \"extrapolated constant\"\n",
+    "rcp26_extrap_const_single.head()"
    ]
   },
   {
@@ -2821,7 +3088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2022-03-15T07:51:15.467192Z",
@@ -3062,7 +3329,7 @@
        "[5 rows x 736 columns]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3091,7 +3358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2022-03-15T07:51:15.513924Z",
@@ -3332,7 +3599,7 @@
        "[5 rows x 736 columns]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3361,7 +3628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2022-03-15T07:51:15.559594Z",
@@ -3602,7 +3869,7 @@
        "[5 rows x 736 columns]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3631,7 +3898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2022-03-15T07:51:15.609142Z",
@@ -3692,7 +3959,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2022-03-15T07:51:16.271440Z",
@@ -3739,7 +4006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2022-03-15T07:51:16.767524Z",
@@ -3848,7 +4115,7 @@
        "IMAGE World  RCP26    start of month kt CF4 / yr Emissions|CF4   11.815992    11.93464   11.997014   11.990841  "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3862,7 +4129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2022-03-15T07:51:16.795891Z",
@@ -3878,7 +4145,7 @@
        "<AxesSubplot:xlabel='time'>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -3904,7 +4171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2022-03-15T07:51:17.024702Z",
@@ -4564,7 +4831,7 @@
        "2000-12-31                   NaN          11.943668  "
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/src/scmdata/errors.py
+++ b/src/scmdata/errors.py
@@ -63,5 +63,3 @@ class InsufficientDataError(Exception):
     """
     Insufficient data is available to interpolate/extrapolate
     """
-
-    pass

--- a/src/scmdata/errors.py
+++ b/src/scmdata/errors.py
@@ -57,3 +57,11 @@ class DuplicateTimesError(ValueError):
         )
 
         super().__init__(msg)
+
+
+class InsufficientDataError(Exception):
+    """
+    Insufficient data is available to interpolate/extrapolate
+    """
+
+    pass

--- a/src/scmdata/time.py
+++ b/src/scmdata/time.py
@@ -12,6 +12,8 @@ import numpy as np
 import pandas as pd
 from dateutil import parser
 
+from scmdata.errors import InsufficientDataError
+
 try:
     import scipy.interpolate
 
@@ -23,14 +25,6 @@ except ImportError:  # pragma: no cover
 
 _TARGET_TYPE = np.int64
 _TARGET_DTYPE = "datetime64[s]"
-
-
-class InsufficientDataError(Exception):
-    """
-    Insufficient data is available to interpolate/extrapolate
-    """
-
-    pass
 
 
 def _float_year_to_datetime(inp: float) -> np.datetime64:
@@ -326,7 +320,7 @@ class TimeseriesConverter:
         ------
         InsufficientDataError
             Length of the time series is too short to convert
-        InsufficientDataError
+
             Target time points are outside the source time points and
             :attr:`extrapolation_type` is 'NONE'
         ImportError

--- a/src/scmdata/time.py
+++ b/src/scmdata/time.py
@@ -338,6 +338,13 @@ class TimeseriesConverter:
             Converted time period average data for timeseries :obj:`values`
         """
         values = np.asarray(values)
+
+        if len(values) == 1 and self.extrapolation_type == "constant":
+            values = np.asarray([values[0], values[0], values[0]])
+            source_time_points = np.asarray(
+                [source_time_points[0], source_time_points[0], source_time_points[0]]
+            )
+
         # Check for nans
         nan_mask = np.isnan(values)
         if nan_mask.sum():

--- a/src/scmdata/time.py
+++ b/src/scmdata/time.py
@@ -336,7 +336,11 @@ class TimeseriesConverter:
         if len(values) == 1 and self.extrapolation_type == "constant":
             values = np.asarray([values[0], values[0], values[0]])
             source_time_points = np.asarray(
-                [source_time_points[0], source_time_points[0], source_time_points[0]]
+                [
+                    source_time_points[0] - 1,
+                    source_time_points[0],
+                    source_time_points[0] + 1,
+                ]
             )
 
         # Check for nans

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -18,9 +18,9 @@ from pint.errors import DimensionalityError, UndefinedUnitError
 
 from scmdata.errors import (
     DuplicateTimesError,
+    InsufficientDataError,
     MissingRequiredColumnError,
     NonUniqueMetadataError,
-    InsufficientDataError,
 )
 from scmdata.run import BaseScmRun, ScmRun, run_append
 from scmdata.testing import (

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -20,6 +20,7 @@ from scmdata.errors import (
     DuplicateTimesError,
     MissingRequiredColumnError,
     NonUniqueMetadataError,
+    InsufficientDataError,
 )
 from scmdata.run import BaseScmRun, ScmRun, run_append
 from scmdata.testing import (
@@ -27,7 +28,6 @@ from scmdata.testing import (
     _check_pandas_less_120,
     assert_scmdf_almost_equal,
 )
-from scmdata.time import InsufficientDataError
 
 
 @pytest.fixture

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -20,6 +20,7 @@ from scmdata.errors import (
     DuplicateTimesError,
     MissingRequiredColumnError,
     NonUniqueMetadataError,
+
 )
 from scmdata.run import BaseScmRun, ScmRun, run_append
 from scmdata.testing import (
@@ -27,6 +28,7 @@ from scmdata.testing import (
     _check_pandas_less_120,
     assert_scmdf_almost_equal,
 )
+from scmdata.time import InsufficientDataError
 
 
 @pytest.fixture
@@ -2265,6 +2267,32 @@ def test_interpolate_nan_constant():
     npt.assert_array_almost_equal(
         res.values.squeeze(), [1.0, 2.0, 3.0, 3.0, 3.0], decimal=4
     )
+
+
+def test_interpolate_single_constant():
+    value = 2.0
+    df = ScmRun(
+        [value],
+        columns={
+            "scenario": ["a_scenario"],
+            "model": ["a_model"],
+            "region": ["World"],
+            "variable": ["Emissions|BC"],
+            "unit": ["Mg /yr"],
+        },
+        index=[2000],
+    )
+    target = [datetime(y, 1, 1) for y in [2000, 2100, 2200, 2300, 2400]]
+    res = df.interpolate(
+        target,
+        extrapolation_type="constant",
+    )
+
+    npt.assert_array_almost_equal(res.values.squeeze(), [value] * 5, decimal=4)
+
+    # Non-constant extrapolation (default) should fail
+    with pytest.raises(InsufficientDataError):
+        df.interpolate(target)
 
 
 def test_time_mean_year_beginning_of_year(test_scm_df_monthly):

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -20,7 +20,6 @@ from scmdata.errors import (
     DuplicateTimesError,
     MissingRequiredColumnError,
     NonUniqueMetadataError,
-
 )
 from scmdata.run import BaseScmRun, ScmRun, run_append
 from scmdata.testing import (

--- a/tests/unit/test_timeseries_convertor.py
+++ b/tests/unit/test_timeseries_convertor.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from scmdata.time import InsufficientDataError, TimeseriesConverter
+from scmdata.time import TimeseriesConverter
+from scmdata.errors import InsufficientDataError
 
 
 @patch("scmdata.time.has_scipy", False)

--- a/tests/unit/test_timeseries_convertor.py
+++ b/tests/unit/test_timeseries_convertor.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from scmdata.time import TimeseriesConverter
 from scmdata.errors import InsufficientDataError
+from scmdata.time import TimeseriesConverter
 
 
 @patch("scmdata.time.has_scipy", False)


### PR DESCRIPTION
# Pull request

Adds a special case where constant extrapolation can be used when there is a single time value. This also moves the definition of `InsufficientDataError` to `scmdata.errors`. Given that it is imported in `scmdata.time` this change is backwards compatible.


Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added

