### PR TITLE
Lazy load plotting libraries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 master
 ------
 
-- (`#209 <https://github.com/openscm/scmdata/pull/209>`_) Ensure that all unit operations in :mod:`scmdata` use :attr:`scmdata.units.UNIT_REGISTRY`. This now defaults to :attr:`openscm_units.unit_registry` instead of unique unit registry for :mod:`scmdata`.
+- (`#209 <https://github.com/openscm/scmdata/pull/209>`_) Lazy import plotting modules to speed up startup time
+- (`#208 <https://github.com/openscm/scmdata/pull/208>`_) Ensure that all unit operations in :mod:`scmdata` use :attr:`scmdata.units.UNIT_REGISTRY`. This now defaults to :attr:`openscm_units.unit_registry` instead of unique unit registry for :mod:`scmdata`.
 - (`#202 <https://github.com/openscm/scmdata/pull/202>`_) Add :func:`scmdata.run.ScmRun.set_meta` to enable setting of metadata for a subset of timeseries
 - (`#194 <https://github.com/openscm/scmdata/pull/194>`_) Deprecate :func:`scmdata.groupby.RunGroupBy.map` in preference to :func:`scmdata.groupby.RunGroupBy.apply` which is identical in functionality. Add :class:`scmdata.ScmRun.apply` for applying a function to each timeseries
 - (`#195 <https://github.com/openscm/scmdata/pull/195>`_) Refactor :mod:`scmdata.database` to a package. The database backends have been moved to :mod:`scmdata.database.backends`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     openscm-units
     packaging
     pandas>=1.0.4, <=1.4.2
+    pint<0.20
     pint-pandas
     python-dateutil
     tqdm

--- a/src/scmdata/plotting.py
+++ b/src/scmdata/plotting.py
@@ -8,25 +8,6 @@ from itertools import cycle
 
 import numpy as np
 
-try:
-    import matplotlib.lines as mlines
-    import matplotlib.patches as mpatches
-    import matplotlib.pyplot as plt
-
-    has_matplotlib = True
-except ImportError:  # pragma: no cover
-    plt = None
-    has_matplotlib = False
-
-try:
-    import seaborn as sns
-
-    has_seaborn = True
-except ImportError:  # pragma: no cover
-    sns = None
-    has_seaborn = False
-
-
 # Copying https://github.com/IAMconsortium/pyam/blob/main/pyam/plotting.py
 RCMIP_SCENARIO_COLOURS = {
     "historical": "black",
@@ -81,7 +62,9 @@ def lineplot(self, time_axis=None, **kwargs):  # pragma: no cover
     :class:`matplotlib.axes._subplots.AxesSubplot`
         Output of call to ``seaborn.lineplot``
     """
-    if not has_seaborn:
+    try:
+        import seaborn as sns
+    except ImportError:
         raise ImportError("seaborn is not installed. Run 'pip install seaborn'")
 
     plt_df = self.long_data(time_axis=time_axis)
@@ -214,7 +197,11 @@ def plumeplot(  # pragma: no cover
     with little testing. In some ways, it is more intended as inspiration for
     other users than as a robust plotting tool.
     """
-    if not has_matplotlib:
+    try:
+        import matplotlib.lines as mlines
+        import matplotlib.patches as mpatches
+        import matplotlib.pyplot as plt
+    except ImportError:  # pragma: no cover
         raise ImportError("matplotlib is not installed. Run 'pip install matplotlib'")
 
     if not pre_calculated:

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -3291,7 +3291,7 @@ def test_lineplot_time_axis(scm_run, time_axis, mod_func):
     pytest.importorskip("seaborn")
     mock_return = 4
 
-    with patch("scmdata.plotting.sns.lineplot") as mock_sns_lineplot:
+    with patch("seaborn.lineplot") as mock_sns_lineplot:
         with patch.object(ScmRun, "long_data") as mock_long_data:
             mock_long_data.return_value = mock_return
 
@@ -3415,7 +3415,7 @@ def test_lineplot_time_axis_junk_error(scm_run):
 
     error_msg = re.escape("time_axis = 'junk")
 
-    with patch("scmdata.plotting.sns.lineplot") as mock_sns_lineplot:
+    with patch("seaborn.lineplot") as mock_sns_lineplot:
         with pytest.raises(NotImplementedError, match=error_msg):
             scm_run.lineplot(time_axis="junk")
 


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added


@znicholls Do you have any strong feelings against lazy importing the plotting libraries? They add >1s of import time which is very obvious when running small python scripts without any plotting. This in combination with #208 reduces `scmdata`'s import time to ~300ms down from >2s.

This pattern is used in other libraries to avoid always importing matplotlib.pyplot (https://github.com/pydata/xarray/blob/7379923de756a2bcc59044d548f8ab7a68b91d4e/xarray/plot/dataarray_plot.py#L979). 


FYI: There is an interesting pattern to allow importing units for type checking only by optionally importing if  `typing.TYPE_CHECKING` is `True` https://github.com/pydata/xarray/blob/7379923de756a2bcc59044d548f8ab7a68b91d4e/xarray/plot/dataarray_plot.py#L979