### PR TITLE
Enable 2 point interpolation/extrapolation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#222 <https://github.com/openscm/scmdata/pull/222>`_) Decrease the minimum number of time points for interpolation to 2
 - (`#221 <https://github.com/openscm/scmdata/pull/221>`_) Add option to :func:`scmdata.ScmRun.interpolate` to allow for interpolation which ignores leap-years. This also fixes a bug where :func:`scmdata.ScmRun.interpolate` converts integer values into unix time. This functionality isn't consistent with the behaviour of the TimePoints class where integers are converted into years.
 - (`#218 <https://github.com/openscm/scmdata/pull/218>`_) Replaced internal calls to :func:`scmdata.groupby.RunGroupby.map` with :func:`scmdata.groupby.RunGroupby.apply`
 - (`#210 <https://github.com/openscm/scmdata/pull/210>`_) Update github actions to avoid the use of a deprecated workflow command

--- a/src/scmdata/time.py
+++ b/src/scmdata/time.py
@@ -336,23 +336,22 @@ class TimeseriesConverter:
         """
         values = np.asarray(values)
 
-        if len(values) == 1 and self.extrapolation_type == "constant":
-            values = np.asarray([values[0], values[0], values[0]])
-            source_time_points = np.asarray(
-                [
-                    source_time_points[0] - 1,
-                    source_time_points[0],
-                    source_time_points[0] + 1,
-                ]
-            )
-
-        # Check for nans
+        # Strip out any nans
         nan_mask = np.isnan(values)
         if nan_mask.sum():
             values = values[~nan_mask]
             source_time_points = source_time_points[~nan_mask]
 
-        if len(values) < 3:
+        if len(values) == 1 and self.extrapolation_type == "constant":
+            values = np.asarray([values[0], values[0]])
+            source_time_points = np.asarray(
+                [
+                    source_time_points[0] - 1,
+                    source_time_points[0],
+                ]
+            )
+
+        if len(values) < 2:
             raise InsufficientDataError
 
         try:

--- a/tests/unit/test_timeseries_convertor.py
+++ b/tests/unit/test_timeseries_convertor.py
@@ -119,7 +119,7 @@ def test_extrapolation_with_nans():
 @pytest.mark.parametrize("extrapolation_type", [None, "linear", "constant"])
 def test_not_enough(count, extrapolation_type):
     if count == 1 and extrapolation_type == "constant":
-        return
+        pytest.skip(reason="Failure not expected")
 
     # This also tests that the single value and constant extrapolation edge-case
     # doesn't work if nan's are involved

--- a/tests/unit/test_timeseries_convertor.py
+++ b/tests/unit/test_timeseries_convertor.py
@@ -24,20 +24,20 @@ def test_no_scipy(scm_run):
 
 
 def test_short_data(combo):
-    timeseriesconverter = TimeseriesConverter(
+    converter = TimeseriesConverter(
         combo.source,
         combo.target,
         combo.interpolation_type,
         combo.extrapolation_type,
     )
-    for a in [[], [0], [0, 1]]:
+    for a in [[], [0]]:
         if len(a) == 1 and combo.extrapolation_type == "constant":
             # Handle a single value and constant extrapolation differently
             # 0 or 2 values should be handled as expected
             continue
 
         with pytest.raises(InsufficientDataError):
-            timeseriesconverter._convert(np.array(a), combo.source, combo.target)
+            converter._convert(np.array(a), combo.source, combo.target)
 
 
 def test_none_extrapolation_error(combo):
@@ -115,9 +115,12 @@ def test_extrapolation_with_nans():
     np.testing.assert_allclose(c.convert_from(source_vals), target_vals, rtol=1e-3)
 
 
-@pytest.mark.parametrize("count", [0, 1, 2])
+@pytest.mark.parametrize("count", [0, 1])
 @pytest.mark.parametrize("extrapolation_type", [None, "linear", "constant"])
 def test_not_enough(count, extrapolation_type):
+    if count == 1 and extrapolation_type == "constant":
+        return
+
     # This also tests that the single value and constant extrapolation edge-case
     # doesn't work if nan's are involved
     source = np.asarray(


### PR DESCRIPTION
# Pull request

Allow for linear interpolation from only two values and constant extrapolation from a single value

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added
- [x] Merge #221 

