### PR TITLE
fix: Bump pandas to the latest version

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -55,12 +55,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [3.7, 3.8, 3.9]
-        exclude:
-          # netCDF4>=1.6.0 doesn't include prebuilt wheels for windows/Python3.7
-          # Older netCDF4 or self-built versions will likely work
-          - os: windows-latest
-            python-version: 3.7
+        python-version: [3.8, 3.9, '3.10', 3.11]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -92,7 +87,7 @@ jobs:
       run: |
           pytest tests -r a --cov=scmdata --cov-report=term-missing --cov-fail-under=$env:MIN_COVERAGE
     - name: Upload coverage to Codecov
-      if: startsWith(runner.os, 'Linux') && matrix.python-version == 3.7
+      if: startsWith(runner.os, 'Linux') && matrix.python-version == 3.11
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
@@ -101,6 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # Pandas v1.1 doesn't build python v3.9 wheels
         python-version: [3.7]
         pandas-version: [1.0.5, 1.1]
 
@@ -134,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7 ]
+        python-version: [ 3.9 ]
         xarray-version: [ 0.16.2, 0.17.0, 0.18.2 ]
 
     steps:
@@ -170,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.9]
 
     steps:
       - name: Checkout repository
@@ -201,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.11]
 
     steps:
     - name: Checkout repository
@@ -226,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10', 3.11]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/test-conda-install.yml
+++ b/.github/workflows/test-conda-install.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10', 3.11]
 
     steps:
     - name: Setup conda

--- a/.github/workflows/test-pypi-install.yml
+++ b/.github/workflows/test-pypi-install.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10', 3.11]
 
     steps:
     - name: Setup python

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#223 <https://github.com/openscm/scmdata/pull/223>`_) Loosen the pandas requirement to cover pandas>=1.4.3. Also support officially support Python 3.10 and 3.11
 - (`#222 <https://github.com/openscm/scmdata/pull/222>`_) Decrease the minimum number of time points for interpolation to 2
 - (`#221 <https://github.com/openscm/scmdata/pull/221>`_) Add option to :func:`scmdata.ScmRun.interpolate` to allow for interpolation which ignores leap-years. This also fixes a bug where :func:`scmdata.ScmRun.interpolate` converts integer values into unix time. This functionality isn't consistent with the behaviour of the TimePoints class where integers are converted into years.
 - (`#218 <https://github.com/openscm/scmdata/pull/218>`_) Replaced internal calls to :func:`scmdata.groupby.RunGroupby.map` with :func:`scmdata.groupby.RunGroupby.apply`

--- a/notebooks/emissions-units-with-pint.ipynb
+++ b/notebooks/emissions-units-with-pint.ipynb
@@ -14,10 +14,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:15.151045Z",
-     "iopub.status.busy": "2022-03-15T07:50:15.150649Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.405237Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.404851Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.089040Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.088699Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.638472Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.617681Z"
     },
     "pycharm": {
      "is_executing": false
@@ -58,10 +58,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.409407Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.409139Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.415601Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.415244Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.657143Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.647847Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.691194Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.690035Z"
     },
     "pycharm": {
      "is_executing": false
@@ -89,10 +89,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.418324Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.418145Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.422863Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.420999Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.696627Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.695889Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.703908Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.702912Z"
     },
     "pycharm": {
      "is_executing": false
@@ -128,10 +128,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.424812Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.424652Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.426834Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.426432Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.709655Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.709065Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.713524Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.712372Z"
     },
     "pycharm": {
      "is_executing": false
@@ -154,10 +154,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.429212Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.429051Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.442050Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.441666Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.720146Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.719726Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.733880Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.733069Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1190,7 +1190,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-03T04:26:34.742762Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.740681Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.746917Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.746594Z"
+    }
+   },
    "outputs": [],
    "source": [
     "unit_registry.define(\"population = [population]\")\n",
@@ -1219,10 +1226,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.445189Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.444446Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.447939Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.447561Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.748219Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.748129Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.750124Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.749874Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1247,10 +1254,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.449738Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.449499Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.452446Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.452099Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.751206Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.751122Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.753246Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.752995Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1277,10 +1284,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.454111Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.453988Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.456553Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.456234Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.754352Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.754269Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.756064Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.755844Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1304,10 +1311,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.458229Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.458083Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.460497Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.460185Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.757241Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.757154Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.758844Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.758597Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1340,10 +1347,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.462240Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.462021Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.465521Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.465139Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.760119Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.760031Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.762148Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.761897Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1378,10 +1385,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.467677Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.467261Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.472503Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.472137Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.763394Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.763306Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.765544Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.765294Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1420,10 +1427,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.474266Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.474135Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.478126Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.477692Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.766820Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.766726Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.769096Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.768857Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1451,10 +1458,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.480975Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.480777Z",
-     "iopub.status.idle": "2022-03-15T07:50:16.485600Z",
-     "shell.execute_reply": "2022-03-15T07:50:16.485047Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.770189Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.770111Z",
+     "iopub.status.idle": "2023-04-03T04:26:34.772381Z",
+     "shell.execute_reply": "2023-04-03T04:26:34.772090Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1489,10 +1496,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:16.488511Z",
-     "iopub.status.busy": "2022-03-15T07:50:16.488268Z",
-     "iopub.status.idle": "2022-03-15T07:50:17.620984Z",
-     "shell.execute_reply": "2022-03-15T07:50:17.620694Z"
+     "iopub.execute_input": "2023-04-03T04:26:34.773833Z",
+     "iopub.status.busy": "2023-04-03T04:26:34.773729Z",
+     "iopub.status.idle": "2023-04-03T04:26:35.380899Z",
+     "shell.execute_reply": "2023-04-03T04:26:35.380553Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1511,6 +1518,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "ar4gwp100uc = UnitConverter(\"N2O\", \"CO2\", context=\"AR4GWP100\")\n",
     "ar4gwp100uc.convert_from(1)"
    ]
@@ -1520,10 +1528,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:17.623311Z",
-     "iopub.status.busy": "2022-03-15T07:50:17.623041Z",
-     "iopub.status.idle": "2022-03-15T07:50:17.630177Z",
-     "shell.execute_reply": "2022-03-15T07:50:17.629909Z"
+     "iopub.execute_input": "2023-04-03T04:26:35.382406Z",
+     "iopub.status.busy": "2023-04-03T04:26:35.382277Z",
+     "iopub.status.idle": "2023-04-03T04:26:35.386984Z",
+     "shell.execute_reply": "2023-04-03T04:26:35.386695Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1558,10 +1566,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:17.632038Z",
-     "iopub.status.busy": "2022-03-15T07:50:17.631868Z",
-     "iopub.status.idle": "2022-03-15T07:50:17.634441Z",
-     "shell.execute_reply": "2022-03-15T07:50:17.634189Z"
+     "iopub.execute_input": "2023-04-03T04:26:35.388291Z",
+     "iopub.status.busy": "2023-04-03T04:26:35.388202Z",
+     "iopub.status.idle": "2023-04-03T04:26:35.390503Z",
+     "shell.execute_reply": "2023-04-03T04:26:35.390257Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1617,10 +1625,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:17.636567Z",
-     "iopub.status.busy": "2022-03-15T07:50:17.636367Z",
-     "iopub.status.idle": "2022-03-15T07:50:17.645914Z",
-     "shell.execute_reply": "2022-03-15T07:50:17.645675Z"
+     "iopub.execute_input": "2023-04-03T04:26:35.391672Z",
+     "iopub.status.busy": "2023-04-03T04:26:35.391587Z",
+     "iopub.status.idle": "2023-04-03T04:26:35.395553Z",
+     "shell.execute_reply": "2023-04-03T04:26:35.395307Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1659,10 +1667,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:17.649000Z",
-     "iopub.status.busy": "2022-03-15T07:50:17.648813Z",
-     "iopub.status.idle": "2022-03-15T07:50:17.651386Z",
-     "shell.execute_reply": "2022-03-15T07:50:17.651088Z"
+     "iopub.execute_input": "2023-04-03T04:26:35.396735Z",
+     "iopub.status.busy": "2023-04-03T04:26:35.396653Z",
+     "iopub.status.idle": "2023-04-03T04:26:35.398749Z",
+     "shell.execute_reply": "2023-04-03T04:26:35.398464Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1690,10 +1698,10 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:17.652976Z",
-     "iopub.status.busy": "2022-03-15T07:50:17.652778Z",
-     "iopub.status.idle": "2022-03-15T07:50:17.654702Z",
-     "shell.execute_reply": "2022-03-15T07:50:17.654480Z"
+     "iopub.execute_input": "2023-04-03T04:26:35.399955Z",
+     "iopub.status.busy": "2023-04-03T04:26:35.399862Z",
+     "iopub.status.idle": "2023-04-03T04:26:35.401756Z",
+     "shell.execute_reply": "2023-04-03T04:26:35.401499Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1727,10 +1735,10 @@
    "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-15T07:50:17.656370Z",
-     "iopub.status.busy": "2022-03-15T07:50:17.656214Z",
-     "iopub.status.idle": "2022-03-15T07:50:17.669594Z",
-     "shell.execute_reply": "2022-03-15T07:50:17.669240Z"
+     "iopub.execute_input": "2023-04-03T04:26:35.402944Z",
+     "iopub.status.busy": "2023-04-03T04:26:35.402861Z",
+     "iopub.status.idle": "2023-04-03T04:26:35.411071Z",
+     "shell.execute_reply": "2023-04-03T04:26:35.410837Z"
     },
     "pycharm": {
      "is_executing": false
@@ -1792,7 +1800,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.16"
   },
   "pycharm": {
    "stem_cell": {

--- a/notebooks/scmrun.ipynb
+++ b/notebooks/scmrun.ipynb
@@ -31,10 +31,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:30.195664Z",
-     "iopub.status.busy": "2022-09-07T05:38:30.195551Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.301241Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.300781Z"
+     "iopub.execute_input": "2023-04-03T04:27:15.601776Z",
+     "iopub.status.busy": "2023-04-03T04:27:15.601392Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.231012Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.229784Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -45,7 +45,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/jared/code/uom/scmdata/src/scmdata/database/_database.py:9: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "/Users/jared/code/uom/scmdata/src/scmdata/database/_database.py:9: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
       "  import tqdm.autonotebook as tqdman\n"
      ]
     }
@@ -68,10 +68,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.330069Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.329940Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.332734Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.332372Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.251220Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.250958Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.253176Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.252927Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -104,10 +104,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.334575Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.334494Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.337064Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.336710Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.254467Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.254363Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.256384Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.256073Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -250,10 +250,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.338835Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.338752Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.400472Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.400068Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.257801Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.257666Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.296613Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.296227Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -284,10 +284,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.402688Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.402599Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.420805Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.420424Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.298194Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.298099Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.309788Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.309509Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -496,10 +496,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.422612Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.422522Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.428531Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.428117Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.311062Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.310975Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.314829Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.314567Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -539,10 +539,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.429949Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.429862Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.443776Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.443420Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.316115Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.316026Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.324555Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.324313Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -751,10 +751,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.445335Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.445237Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.509687Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.509249Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.325745Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.325660Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.365777Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.365525Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -962,10 +962,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.511174Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.511081Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.571507Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.571145Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.367049Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.366953Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.403820Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.403533Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1184,10 +1184,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.573550Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.573465Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.575823Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.575475Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.405162Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.405057Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.407067Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.406832Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1214,10 +1214,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.577727Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.577643Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.586265Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.585833Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.408292Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.408203Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.413985Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.413732Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1255,10 +1255,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.588200Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.588116Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.609087Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.608702Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.415161Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.415074Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.428103Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.427840Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1394,10 +1394,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.611062Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.610976Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.624356Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.624003Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.429305Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.429226Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.437205Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.436969Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1537,10 +1537,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.626343Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.626254Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.639643Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.639284Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.438478Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.438387Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.446481Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.446217Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1665,10 +1665,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.641511Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.641413Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.675411Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.675044Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.447644Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.447555Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.468260Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.468010Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1804,10 +1804,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.677373Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.677282Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.690963Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.690563Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.469589Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.469487Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.477799Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.477555Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1845,10 +1845,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.692935Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.692849Z",
-     "iopub.status.idle": "2022-09-07T05:38:31.707872Z",
-     "shell.execute_reply": "2022-09-07T05:38:31.707512Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.479033Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.478950Z",
+     "iopub.status.idle": "2023-04-03T04:27:16.487912Z",
+     "shell.execute_reply": "2023-04-03T04:27:16.487666Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2035,10 +2035,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:31.709783Z",
-     "iopub.status.busy": "2022-09-07T05:38:31.709697Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.817680Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.817294Z"
+     "iopub.execute_input": "2023-04-03T04:27:16.489038Z",
+     "iopub.status.busy": "2023-04-03T04:27:16.488956Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.122359Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.122078Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2218,6 +2218,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "rcp26.filter(variable=[\"*CO2*\", \"*CH4*\", \"*N2O*\"]).convert_unit(\n",
     "    \"Mt CO2 / yr\", context=\"AR4GWP100\"\n",
     ").timeseries()"
@@ -2239,10 +2240,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.819942Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.819847Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.837521Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.837112Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.123732Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.123639Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.134321Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.133998Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2280,10 +2281,10 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.839875Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.839784Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.894854Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.894338Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.135510Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.135424Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.168931Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.168645Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2485,10 +2486,10 @@
    "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.897093Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.897005Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.902191Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.901794Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.170252Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.170165Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.173549Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.173198Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2515,10 +2516,10 @@
    "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.904124Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.904039Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.908724Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.908343Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.174808Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.174714Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.178179Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.177919Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2560,10 +2561,10 @@
    "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.910781Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.910696Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.916698Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.916290Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.179505Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.179421Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.183786Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.183372Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2662,10 +2663,10 @@
    "execution_count": 24,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.918705Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.918621Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.923932Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.923572Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.185147Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.185026Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.189373Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.189106Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2698,10 +2699,10 @@
    "execution_count": 25,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.925834Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.925749Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.941737Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.941374Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.190669Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.190571Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.200285Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.200011Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2740,10 +2741,10 @@
    "execution_count": 26,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.943760Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.943674Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.948642Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.948295Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.201596Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.201503Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.205040Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.204761Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2791,10 +2792,10 @@
    "execution_count": 27,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.950671Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.950588Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.960885Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.960481Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.206336Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.206247Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.212956Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.212699Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2833,10 +2834,10 @@
    "execution_count": 28,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.962860Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.962775Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.972457Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.972022Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.214168Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.214086Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.219779Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.219520Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2880,10 +2881,10 @@
    "execution_count": 29,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.975254Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.975152Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.978218Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.977868Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.221171Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.221076Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.223265Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.223016Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2948,10 +2949,10 @@
    "execution_count": 30,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.980745Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.980650Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.983656Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.983320Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.224572Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.224483Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.226714Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.226466Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2989,10 +2990,10 @@
    "execution_count": 31,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.985566Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.985482Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.988458Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.988071Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.227922Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.227840Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.229975Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.229748Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -3019,10 +3020,10 @@
    "execution_count": 32,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-09-07T05:38:32.990776Z",
-     "iopub.status.busy": "2022-09-07T05:38:32.990694Z",
-     "iopub.status.idle": "2022-09-07T05:38:32.993448Z",
-     "shell.execute_reply": "2022-09-07T05:38:32.993078Z"
+     "iopub.execute_input": "2023-04-03T04:27:17.231130Z",
+     "iopub.status.busy": "2023-04-03T04:27:17.231048Z",
+     "iopub.status.idle": "2023-04-03T04:27:17.233039Z",
+     "shell.execute_reply": "2023-04-03T04:27:17.232805Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -3068,7 +3069,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.16"
   },
   "pycharm": {
    "stem_cell": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,10 @@ classifiers =
     License :: OSI Approved :: BSD License
     Intended Audience :: Developers
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 packages = find:
@@ -34,7 +35,7 @@ install_requires =
     numpy
     openscm-units
     packaging
-    pandas>=1.0.4, <=1.4.2
+    pandas>=1.0.4, <2
     pint<0.20
     pint-pandas
     python-dateutil

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -1715,7 +1715,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
             ts.index = pd.MultiIndex.from_frame(ts_idx.fillna(na_override))
 
         group_cols = list(set(ts.index.names) - set(cols))
-        grouper = ts.groupby(group_cols)
+        grouper = ts.groupby(group_cols, group_keys=False)
 
         # This is a subset of the available functions
         #  https://pandas.pydata.org/pandas-docs/stable/reference/groupby.html
@@ -2537,7 +2537,7 @@ def run_append(
         # Convert back from str
         for c in nan_cols[nan_cols].index:
             new_meta[c].replace("nan", np.nan, inplace=True)
-        for c, dtype in orig_dtypes.iteritems():
+        for c, dtype in orig_dtypes.items():
             new_meta[c] = new_meta[c].astype(dtype)
 
         ret._meta = pd.MultiIndex.from_frame(new_meta.astype("category"))

--- a/tests/integration/test_processing.py
+++ b/tests/integration/test_processing.py
@@ -414,7 +414,9 @@ def test_exceedance_probabilities_over_time(
     exp = pd.DataFrame(
         np.array(exp_vals)[np.newaxis, :],
         index=exp_idx,
-        columns=test_processing_scm_df.time_points.to_index(),
+        # This forces the coercion to a DateTimeIndex which now happens automatically for
+        # pandas>=1.4.3
+        columns=pd.Index(test_processing_scm_df.time_points.to_index()),
     )
     exp.index = exp.index.set_levels(
         [_get_calculate_exeedance_probs_expected_name(output_name, threshold)],
@@ -424,7 +426,7 @@ def test_exceedance_probabilities_over_time(
         level="unit",
     )
 
-    pdt.assert_frame_equal(res, exp, check_like=True, check_column_type=False)
+    pdt.assert_frame_equal(res, exp, check_like=True, check_names=False)
 
 
 def test_exceedance_probabilities_over_time_multiple_res(
@@ -444,7 +446,11 @@ def test_exceedance_probabilities_over_time_multiple_res(
         start.meta.drop(["ensemble_member"], axis="columns").drop_duplicates()
     )
 
-    exp = pd.DataFrame(exp_vals, index=exp_idx, columns=start.time_points.to_index())
+    exp = pd.DataFrame(
+        exp_vals,
+        index=exp_idx,
+        columns=pd.Index(start.time_points.to_index()),
+    )
     exp.index = exp.index.set_levels(
         [_get_calculate_exeedance_probs_expected_name(None, threshold)],
         level="variable",
@@ -453,7 +459,7 @@ def test_exceedance_probabilities_over_time_multiple_res(
         level="unit",
     )
 
-    pdt.assert_frame_equal(res, exp, check_like=True, check_column_type=False)
+    pdt.assert_frame_equal(res, exp, check_like=True, check_names=False)
 
 
 def test_exceedance_probabilities_over_time_multiple_grouping(
@@ -478,7 +484,7 @@ def test_exceedance_probabilities_over_time_multiple_grouping(
     exp = pd.DataFrame(
         exp_vals[np.newaxis, :],
         index=exp_idx,
-        columns=start.time_points.to_index(),
+        columns=pd.Index(start.time_points.to_index()),
     )
     exp.index = exp.index.set_levels(
         [_get_calculate_exeedance_probs_expected_name(None, threshold)],

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -99,7 +99,7 @@ def test_no_scipy(scm_run):
     with pytest.raises(
         ImportError, match="scipy is not installed. Run 'pip install scipy'"
     ):
-        scm_run.integrate()
+        scm_run.cumtrapz()
 
 
 @OPS_MARK
@@ -222,7 +222,7 @@ def perform_pint_op(base, pint_obj, op):
     base_ts = base_ts.pint.quantify(level=unit_level)
 
     out = []
-    for _, series in base_ts.iteritems():
+    for _, series in base_ts.items():
         if op == "add":
             op_series = series + pint_obj
 


### PR DESCRIPTION
# Pull request

Bump pandas and update tests to handle the latest version of pandas. This also allows the use of newer versions of Python during CI. This MR removes running the tests on Python v3.8 and adds Python v3.11.

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added
- [x] #221 to fix the notebooks

Closes #203 #219 
