### PR TITLE
refactor: Always return results from `inplace` operations.

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -96,7 +96,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Pandas v1.1 doesn't build python v3.9 wheels
         python-version: [3.8]
         pandas-version: [1.0.5, 1.1]
 
@@ -112,7 +111,7 @@ jobs:
           pip install --upgrade pip wheel
           pip install -e .[tests,plotting,optional]
 
-          pip install pandas==${{ matrix.pandas-version }}
+          pip install pandas==${{ matrix.pandas-version }} numpy=1.20.0
 
       - name: Test with pytest
         env:

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        pandas-version: [1.0.5, 1.1]
+        pandas-version: [1.1]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -111,7 +111,7 @@ jobs:
           pip install --upgrade pip wheel
           pip install -e .[tests,plotting,optional]
 
-          pip install pandas==${{ matrix.pandas-version }} numpy=1.20.0
+          pip install pandas==${{ matrix.pandas-version }} numpy==1.20.0
 
       - name: Test with pytest
         env:

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         # Pandas v1.1 doesn't build python v3.9 wheels
-        python-version: [3.7]
+        python-version: [3.8]
         pandas-version: [1.0.5, 1.1]
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 master
 ------
 
-- (`#232 <https://github.com/openscm/scmdata/pull/232>`_) Update inplace operations to always return a result (closes `#230 <https://github.com/openscm/scmdata/issues/230>`_)
+- (`#232 <https://github.com/openscm/scmdata/pull/232>`_) Update inplace operations to always return a result (closes `#230 <https://github.com/openscm/scmdata/issues/230>`_). Removes support for pandas==1.0.5
 
 v0.15.0
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 master
 ------
 
+- (`#232 <https://github.com/openscm/scmdata/pull/232>`_) Update inplace operations to always return a result (closes `#230 <https://github.com/openscm/scmdata/issues/230>`_)
+
 v0.15.0
 -------
 

--- a/notebooks/summary-statistics.ipynb
+++ b/notebooks/summary-statistics.ipynb
@@ -273,7 +273,7 @@
       "\n",
       "        Returns\n",
       "        -------\n",
-      "        :class:`pandas.DataFrame` or :class:`pandas.Series`  or :class:`scmdata.ScmRun`\n",
+      "        :class:`pandas.DataFrame` or :class:`pandas.Series` or :class:`scmdata.ScmRun`\n",
       "            The result of ``operation``, grouped by all columns in :attr:`meta`\n",
       "            other than :obj:`cols`\n",
       "\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     six
     xarray
     importlib-metadata < 5.0; python_version < '3.8'
+    typing-extensions < 5.0
 
 setup_requires =
     setuptools >= 41

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     numpy
     openscm-units
     packaging
-    pandas>=1.0.4, <2
+    pandas>=1.1, <2
     pint<0.20
     pint-pandas
     python-dateutil

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -10,7 +10,18 @@ import numbers
 import os
 import warnings
 from logging import getLogger
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import cftime
 import numpy as np
@@ -2381,7 +2392,7 @@ def _merge_metadata(metadata):
 
 
 def run_append(
-    runs: Iterable[T],
+    runs: Sequence[T],
     inplace: bool = False,
     duplicate_msg: Union[str, bool] = True,
     metadata: Optional[MetadataType] = None,
@@ -2458,7 +2469,7 @@ def run_append(
 
         No runs are provided to be appended
     """
-    if not isinstance(runs, list):
+    if not isinstance(runs, Sequence):
         raise TypeError("runs is not a list")
 
     if not len(runs):

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -54,6 +54,8 @@ _logger = getLogger(__name__)
 MetadataType = Dict[str, Union[str, int, float]]
 ApplyCallable = Callable[[pd.DataFrame], Union[pd.DataFrame, pd.Series, float]]
 
+T = TypeVar("T", bound="BaseScmRun")
+
 
 def _read_file(  # pylint: disable=missing-return-doc
     fnames: str, required_cols: Tuple[str], *args: Any, **kwargs: Any
@@ -303,7 +305,7 @@ def _from_ts(
     return df, meta
 
 
-def _get_target(run, inplace):
+def _get_target(run: T, inplace: bool) -> T:
     if inplace:
         return run
     else:
@@ -315,7 +317,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
     Base class of a data container for timeseries data
     """
 
-    required_cols = ("variable", "unit")
+    required_cols: Tuple[str, ...] = ("variable", "unit")
     """
     Required metadata columns
 
@@ -2368,9 +2370,6 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         return ret
 
 
-T = TypeVar("T", bound=BaseScmRun)
-
-
 def _merge_metadata(metadata):
     res = metadata[0].copy()
 
@@ -2577,7 +2576,7 @@ class ScmRun(BaseScmRun):
     Data container for holding one or many time-series of SCM data.
     """
 
-    required_cols = ("model", "scenario", "region", "variable", "unit")
+    required_cols: Tuple[str, ...] = ("model", "scenario", "region", "variable", "unit")
     """
     Minimum metadata columns required by an ScmRun.
 

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -10,18 +10,7 @@ import numbers
 import os
 import warnings
 from logging import getLogger
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import cftime
 import numpy as np

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -2393,7 +2393,7 @@ def _merge_metadata(metadata):
 
 
 def run_append(
-    runs: List[T],
+    runs: Iterable[T],
     inplace: bool = False,
     duplicate_msg: Union[str, bool] = True,
     metadata: Optional[MetadataType] = None,

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -10,7 +10,18 @@ import numbers
 import os
 import warnings
 from logging import getLogger
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import cftime
 import numpy as np
@@ -19,6 +30,7 @@ import pandas as pd
 import pandas.io.common
 import pint
 from dateutil import parser
+from typing_extensions import Self
 
 import scmdata.units
 
@@ -748,7 +760,9 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         df._df.values[:] = res.T
         return df
 
-    def drop_meta(self, columns: Union[list, str], inplace: Optional[bool] = False):
+    def drop_meta(
+        self, columns: Union[list, str], inplace: Optional[bool] = False
+    ) -> Self:
         """
         Drop meta columns out of the Run
 
@@ -757,12 +771,16 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         columns
             The column or columns to drop
         inplace
-            If True, do operation inplace and return None.
+            If True, do operation inplace, otherwise a copy is performed.
 
         Raises
         ------
         KeyError
             If any of the columns do not exist in the meta :class:`DataFrame`
+
+        Returns
+        -------
+            Object without the specified meta columns.
         """
         ret = _get_target(self, inplace)
 
@@ -781,8 +799,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         if ret._duplicated_meta():
             raise NonUniqueMetadataError(ret.meta)
 
-        if not inplace:
-            return ret
+        return ret
 
     @property
     def meta_attributes(self):
@@ -1048,7 +1065,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         inplace: bool = False,
         log_if_empty: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Self:
         """
         Return a filtered ScmRun (i.e., a subset of the data).
 
@@ -1117,7 +1134,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
             timeseries satisfying the filters
 
         inplace
-            If True, do operation inplace and return None
+            If True, do operation inplace, otherwise a copy is performed.
 
         log_if_empty
             If ``True``, log a warning level message if the result is empty.
@@ -1146,7 +1163,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         Returns
         -------
         :class:`ScmRun <scmdata.run.ScmRun>`
-            If not ``inplace``, return a new instance with the filtered data.
+            Object containing a filtered subset of timeseries.
         """
         ret = copy.copy(self) if not inplace else self
 
@@ -1177,10 +1194,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         if log_if_empty and ret.empty:
             _logger.warning("Filtered ScmRun is empty!", stack_info=True)
 
-        if not inplace:
-            return ret
-
-        return None
+        return ret
 
     # pylint doesn't recognise ',' in returns type definition
     def _apply_filters(  # pylint: disable=missing-return-doc
@@ -1683,7 +1697,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
 
         Returns
         -------
-        :class:`pandas.DataFrame` or :class:`pandas.Series`  or :class:`scmdata.ScmRun`
+        :class:`pandas.DataFrame` or :class:`pandas.Series` or :class:`scmdata.ScmRun`
             The result of ``operation``, grouped by all columns in :attr:`meta`
             other than :obj:`cols`
 
@@ -1970,7 +1984,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         context: Optional[str] = None,
         inplace: bool = False,
         **kwargs: Any,
-    ):
+    ) -> Self:
         """
         Convert the units of a selection of timeseries.
 
@@ -1988,7 +2002,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
             CO2-equivalent calculations will raise :class:`DimensionalityError`.
 
         inplace
-            If True, apply the conversion inplace and return None
+            If True, apply the conversion inplace, otherwise a copy is performed.
 
         **kwargs
             Extra arguments which are passed to :meth:`~ScmRun.filter` to
@@ -1998,8 +2012,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         Returns
         -------
         :class:`ScmRun <scmdata.run.ScmRun>`
-            If :obj:`inplace` is not ``False``, a new :class:`ScmRun <scmdata.run.ScmRun>` instance
-            with the converted units.
+            A :class:`ScmRun <scmdata.run.ScmRun>` object containing converted units.
 
         Notes
         -----
@@ -2053,8 +2066,8 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
             ret = ret.groupby("unit").apply(apply_units)
 
         ret = run_append([ret, to_not_convert], inplace=inplace)
-        if not inplace:
-            return ret
+
+        return ret
 
     @staticmethod
     def _check_unit_context(dat, context):
@@ -2117,12 +2130,12 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
 
     def append(
         self,
-        other,
+        other: "BaseScmRun",
         inplace: bool = False,
         duplicate_msg: Union[str, bool] = True,
         metadata: Optional[MetadataType] = None,
         **kwargs: Any,
-    ):
+    ) -> Self:
         """
         Append additional data to the current data.
 
@@ -2131,11 +2144,12 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         Parameters
         ----------
         other
-            Data (in format which can be cast to :class:`ScmRun <scmdata.run.ScmRun>`) to append
+            Data (in format which can be cast to :class:`ScmRun <scmdata.run.ScmRun>`) to
+             append.
 
         inplace
-            If ``True``, append data in place and return ``None``. Otherwise, return a
-            new :class:`ScmRun <scmdata.run.ScmRun>` instance with the appended data.
+            If ``True``, append data in place, modifying the current object. Otherwise,
+            a new :class:`ScmRun <scmdata.run.ScmRun>` instance is created.
 
         duplicate_msg
             If ``True``, raise a :class:`scmdata.errors.NonUniqueMetadataError` error
@@ -2156,8 +2170,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         Returns
         -------
         :class:`ScmRun <scmdata.run.ScmRun>`
-            If not :obj:`inplace`, return a new :class:`ScmRun <scmdata.run.ScmRun>` instance
-            containing the result of the append.
+            Object containing the results of appending the timeseries in ``other``.
 
         Raises
         ------
@@ -2289,8 +2302,6 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
 
         NotImplementedError
             If `axis` is anything other than 0
-
-
         """
         if dim is not None:
             raise ValueError("ScmRun.reduce does not handle dim. Use axis instead")
@@ -2330,7 +2341,7 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
 
             return type(self)(data, index=index, columns=meta)
 
-    def round(self, decimals=3, inplace=False):
+    def round(self, decimals=3, inplace=False) -> Self:
         """
         Round data to a given number of decimal places.
 
@@ -2344,13 +2355,12 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
             Number of decimal places to round each value to.
 
         inplace : bool
-            If True, apply the conversion inplace and return None
+            If True, apply the conversion inplace, otherwise a copy is performed.
 
         Returns
         -------
         :class:`ScmRun <scmdata.run.ScmRun>`
-            If :obj:`inplace` is not ``False``, a new :class:`ScmRun <scmdata.run.ScmRun>` instance
-            with the rounded values.
+            :class:`ScmRun <scmdata.run.ScmRun>` containing the rounded values.
 
         """
         ret = _get_target(self, inplace)
@@ -2366,8 +2376,10 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
 
         ret._df = ret._df.round(decimals)
 
-        if not inplace:
-            return ret
+        return ret
+
+
+T = TypeVar("T", bound=BaseScmRun)
 
 
 def _merge_metadata(metadata):
@@ -2381,11 +2393,11 @@ def _merge_metadata(metadata):
 
 
 def run_append(
-    runs: List[BaseScmRun],
+    runs: List[T],
     inplace: bool = False,
     duplicate_msg: Union[str, bool] = True,
     metadata: Optional[MetadataType] = None,
-) -> Optional[BaseScmRun]:
+) -> T:
     """
     Append together many objects.
 
@@ -2425,8 +2437,8 @@ def run_append(
         The runs to append. Values will be attempted to be cast to :class:`ScmRun <scmdata.run.ScmRun>`.
 
     inplace
-        If ``True``, then the operation updates the first item in :obj:`runs` and returns
-        ``None``.
+        If ``True``, then the operation updates the first item in :obj:`runs` inplace.
+        Otherwise, the results are appended to a new object.
 
     duplicate_msg
         If ``True``, raise a ``NonUniqueMetadataError`` error so the user can
@@ -2442,8 +2454,8 @@ def run_append(
     Returns
     -------
     :class:`ScmRun <scmdata.run.ScmRun>`
-        If not :obj:`inplace`, the return value is the object containing the merged
-        data. The resultant class will be determined by the type of the first object.
+        Object containing the appended data. The resultant class will be determined by
+        the type of the first object.
 
     Raises
     ------
@@ -2547,8 +2559,7 @@ def run_append(
     else:
         ret.metadata = _merge_metadata([r.metadata for r in runs])
 
-    if not inplace:
-        return ret
+    return ret
 
 
 def _handle_potential_duplicates_in_append(data, duplicate_msg):

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1990,7 +1990,7 @@ def test_append_duplicate_times_error_msg(scm_run):
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_append_inplace(scm_run):
+def test_append_inplace_with_warning(scm_run):
     other = scm_run * 2
 
     obs = scm_run.filter(scenario="a_scenario2").timeseries().squeeze()

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -30,6 +30,8 @@ from scmdata.testing import (
     get_single_ts,
 )
 
+inplace_params = pytest.mark.parametrize("inplace", [True, False])
+
 
 @pytest.fixture
 def scm_run_interpolated(scm_run):
@@ -671,13 +673,24 @@ def test_filter_year_list(year_list, test_scm_run_datetimes):
     assert (res["year"].unique() == expected).all()
 
 
-def test_filter_inplace(test_scm_run_datetimes):
-    test_scm_run_datetimes.filter(year=2005, inplace=True)
-    expected = dt.datetime(2005, 6, 17, 12)
+@inplace_params
+def test_filter_inplace(test_scm_run_datetimes, inplace):
+    exp = test_scm_run_datetimes.filter(year=2005, inplace=False)
 
-    unique_time = test_scm_run_datetimes["time"].unique()
-    assert len(unique_time) == 1
-    assert unique_time[0] == expected
+    if inplace:
+        res = test_scm_run_datetimes.filter(year=2005, inplace=True)
+        assert id(res) == id(test_scm_run_datetimes)
+
+        expected = dt.datetime(2005, 6, 17, 12)
+
+        unique_time = test_scm_run_datetimes["time"].unique()
+        assert len(unique_time) == 1
+        assert unique_time[0] == expected
+    else:
+        res = test_scm_run_datetimes.filter(year=2005, inplace=False)
+        assert id(res) != id(test_scm_run_datetimes)
+
+    assert_scmdf_almost_equal(exp, res)
 
 
 @pytest.mark.parametrize("test_month", [6, "June", "Jun", "jun", ["Jun", "jun"]])
@@ -3340,7 +3353,7 @@ def test_get_meta_no_duplicates(scm_run, no_duplicates):
         ]
 
 
-@pytest.mark.parametrize("inplace", [True, False])
+@inplace_params
 @pytest.mark.parametrize("label", ["extra_meta", ["extra", "other"]])
 def test_drop_meta(scm_run, label, inplace):
     if type(label) == str:
@@ -3352,8 +3365,8 @@ def test_drop_meta(scm_run, label, inplace):
             assert lbl in scm_run.meta.columns
 
     if inplace:
-        scm_run.drop_meta(label, inplace=True)
-        res = scm_run
+        res = scm_run.drop_meta(label, inplace=True)
+        assert id(res) == id(scm_run)
     else:
         res = scm_run.drop_meta(label, inplace=False)
         assert id(res) != id(scm_run)
@@ -3630,6 +3643,29 @@ def test_append_long_run(tax1, tax2):
     assert res.get_unique_meta("scenario") == ["run1", "run2"]
 
 
+@inplace_params
+@pytest.mark.parametrize("use_cls_method", [True, False])
+def test_append_inplace(scm_run, inplace, use_cls_method):
+    run1 = scm_run.copy()
+    run1["ensemble_member"] = 1
+    run2 = scm_run.copy()
+    run2["ensemble_member"] = 2
+
+    exp = run_append([run1, run2])
+
+    if use_cls_method:
+        res = run1.append(run2, inplace=inplace)
+    else:
+        res = run_append([run1, run2], inplace=inplace)
+
+    if inplace:
+        assert id(res) == id(run1)
+    else:
+        assert id(res) != id(run1)
+
+    assert_scmdf_almost_equal(res, exp)
+
+
 @pytest.mark.parametrize(
     "metadata_1,metadata_2,metadata,expected",
     (
@@ -3653,7 +3689,7 @@ def test_append_long_run(tax1, tax2):
         ),
     ),
 )
-@pytest.mark.parametrize("inplace", [True, False])
+@inplace_params
 @pytest.mark.parametrize("use_cls_method", [True, False])
 def test_append_metadata(
     scm_run, metadata_1, metadata_2, metadata, expected, inplace, use_cls_method
@@ -3669,9 +3705,6 @@ def test_append_metadata(
         res = run1.append(run2, metadata=metadata, inplace=inplace)
     else:
         res = run_append([run1, run2], metadata=metadata, inplace=inplace)
-
-    if inplace:
-        res = run1
 
     assert res.metadata == expected
 


### PR DESCRIPTION
Updates operations that could be performed inplace to always return an ScmRun. The `inplace` argument dictates whether it is a copy or not.

This also fixes a typing issue for `run_append` which had a return type of `BaseScmRun | None`. It now returns the type of the items that are being appended.

The current implementation isn't perfect, as I don't believe you differentiate the type for the first item vs the rest of the list. Python assumes that a list has a homogenous type which results in a mixed type list being typed as `list[A | B]`.

For example:
```
a: ScmRun = ...
b: BaseScmRun = ...

res = run_append([a, b])
```

res will have an inferred type of `ScmRun | BaseScmRun` rather than the expected `ScmRun`. Not perfect, but if we type it as a tuple we can differentiate the first type vs the rest. @mikapfl you might have a better solution for this.

Typing as a tuple wouldn't break any functionality, but would result in type errors in downstream code.

Closes #230

# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <https://github.com/openscm/scmdata/pull/XX>`_) Added feature which does something
- (`#XX <https://github.com/openscm/scmdata/pull/XX>`_) Fixed bug identified in (`#YY <https://github.com/openscm/scmdata/issues/YY>`_)
```
