### PR TITLE
faster ScmRun.__setitem__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ master
 ------
 
 - (`#248 <https://github.com/openscm/scmdata/pull/248>`_) Correctly filter the time index of empty ScmRuns. Resolves #245
+- (`#247 <https://github.com/openscm/scmdata/pull/247>`_) Better performance for ScmRun.__setitem__.
 
 v0.15.1
 -------

--- a/src/scmdata/run.py
+++ b/src/scmdata/run.py
@@ -595,56 +595,6 @@ class BaseScmRun(OpsMixin):  # pylint: disable=too-many-public-methods
         """
         Update metadata
 
-        Notes
-        -----
-        If the meta values changes are applied to a filtered subset, the change might be reflected
-        in the original :class:`ScmRun <scmdata.run.ScmRun>` object.
-
-        .. code:: python
-
-            >>> df
-            <scmdata.ScmRun (timeseries: 3, timepoints: 3)>
-            Time:
-                Start: 2005-01-01T00:00:00
-                End: 2015-01-01T00:00:00
-            Meta:
-                   model     scenario region             variable   unit climate_model
-                0  a_iam   a_scenario  World       Primary Energy  EJ/yr       a_model
-                1  a_iam   a_scenario  World  Primary Energy|Coal  EJ/yr       a_model
-                2  a_iam  a_scenario2  World       Primary Energy  EJ/yr       a_model
-            >>> df["climate_model"] = ["a_model", "a_model", "b_model"]
-            >>> df
-            <scmdata.ScmRun (timeseries: 3, timepoints: 3)>
-            Time:
-                Start: 2005-01-01T00:00:00
-                End: 2015-01-01T00:00:00
-            Meta:
-                   model     scenario region             variable   unit climate_model
-                0  a_iam   a_scenario  World       Primary Energy  EJ/yr       a_model
-                1  a_iam   a_scenario  World  Primary Energy|Coal  EJ/yr       a_model
-                2  a_iam  a_scenario2  World       Primary Energy  EJ/yr       b_model
-            >>> df2 = df.filter(variable="Primary Energy")
-            >>> df2["pe_only"] = True
-            >>> df2
-            <scmdata.ScmRun (timeseries: 2, timepoints: 3)>
-            Time:
-                Start: 2005-01-01T00:00:00
-                End: 2015-01-01T00:00:00
-            Meta:
-                   model     scenario region             variable   unit climate_model pe_only
-                0  a_iam   a_scenario  World       Primary Energy  EJ/yr       a_model    True
-                2  a_iam  a_scenario2  World       Primary Energy  EJ/yr       b_model    True
-            >>> df
-            <scmdata.ScmRun (timeseries: 3, timepoints: 3)>
-            Time:
-                Start: 2005-01-01T00:00:00
-                End: 2015-01-01T00:00:00
-            Meta:
-                   model     scenario region             variable   unit climate_model pe_only
-                0  a_iam   a_scenario  World       Primary Energy  EJ/yr       a_model    True
-                1  a_iam   a_scenario  World  Primary Energy|Coal  EJ/yr       a_model     NaN
-                2  a_iam  a_scenario2  World       Primary Energy  EJ/yr       b_model    True
-
         Parameters
         ----------
         key

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -549,45 +549,62 @@ def test_get_item_not_in_meta(scm_run):
         scm_run[dud_key]
 
 
-def test_set_item(scm_run):
-    scm_run["model"] = ["a_iam", "b_iam", "c_iam"]
-    assert all(scm_run["model"] == ["a_iam", "b_iam", "c_iam"])
+class TestSetItem:
+    def test_multiple(self, scm_run):
+        scm_run["model"] = ["a_iam", "b_iam", "c_iam"]
+        assert all(scm_run["model"] == ["a_iam", "b_iam", "c_iam"])
 
+    def test_single(self, scm_run):
+        scm_run["model"] = "b_iam"
+        assert all(scm_run["model"] == ["b_iam", "b_iam", "b_iam"])
 
-def test_set_item_single(scm_run):
-    scm_run["model"] = "b_iam"
-    assert all(scm_run["model"] == ["b_iam", "b_iam", "b_iam"])
+    def test_not_in_meta(self, scm_run):
+        with pytest.raises(ValueError):
+            scm_run["junk"] = ["hi", "bye"]
 
+        scm_run["junk"] = ["hi", "bye", "ciao"]
+        assert all(scm_run["junk"] == ["hi", "bye", "ciao"])
 
-def test_set_item_not_in_meta(scm_run):
-    with pytest.raises(ValueError):
-        scm_run["junk"] = ["hi", "bye"]
+        scm_run["junk"] = ["hi", "bye", "bye"]
+        assert all(scm_run["junk"] == ["hi", "bye", "bye"])
 
-    scm_run["junk"] = ["hi", "bye", "ciao"]
-    assert all(scm_run["junk"] == ["hi", "bye", "ciao"])
+    @pytest.mark.parametrize("key", ("model", "junk"))
+    def test_nan(self, scm_run, key):
+        scm_run[key] = ["hi", np.NaN, "bye"]
+        assert all(scm_run[key] == ["hi", "nan", "bye"])
 
-    scm_run["junk"] = ["hi", "bye", "bye"]
-    assert all(scm_run["junk"] == ["hi", "bye", "bye"])
+    @pytest.mark.parametrize("key", ("model", "junk"))
+    def test_nan_single(self, scm_run, key):
+        scm_run[key] = np.nan
+        assert all(np.isnan(scm_run[key]))
 
+    @pytest.mark.parametrize("key", ("model", "junk"))
+    def test_nan_float(self, scm_run, key):
+        scm_run[key] = [1, np.NaN, 2]
+        assert scm_run[key][0] == 1
+        assert np.isnan(scm_run[key][1])
+        assert scm_run[key][2] == 2
 
-@pytest.mark.parametrize("key", ("model", "junk"))
-def test_set_item_nan(scm_run, key):
-    scm_run[key] = ["hi", np.NaN, "bye"]
-    assert all(scm_run[key] == ["hi", "nan", "bye"])
+    def test_filter(self, scm_run):
+        filtered = scm_run.filter(variable="Primary Energy|Coal")
+        assert len(filtered) == 1
+        filtered["model"] = "other_model"
+        assert (scm_run["model"] == ["a_iam", "a_iam", "a_iam"]).all()
 
+    def test_filter_full(self, scm_run):
+        filtered = scm_run.filter(model="a_iam")
+        assert len(filtered) == 3
+        filtered["climate_model"] = "other_model"
+        assert (scm_run["climate_model"] == "a_model").all()
 
-@pytest.mark.parametrize("key", ("model", "junk"))
-def test_set_item_nan_single(scm_run, key):
-    scm_run[key] = np.nan
-    assert all(np.isnan(scm_run[key]))
-
-
-@pytest.mark.parametrize("key", ("model", "junk"))
-def test_set_item_nan_float(scm_run, key):
-    scm_run[key] = [1, np.NaN, 2]
-    assert scm_run[key][0] == 1
-    assert np.isnan(scm_run[key][1])
-    assert scm_run[key][2] == 2
+    def test_filter_new(self, scm_run):
+        filtered = scm_run.filter(variable="Primary Energy|Coal")
+        assert len(filtered) == 1
+        filtered["new_key"] = "other_model"
+        filtered2 = scm_run.filter(model="a_iam")
+        assert len(filtered2) == 3
+        filtered2["new_key"] = "third model"
+        assert "new_key" not in scm_run.meta.columns
 
 
 def test_len(scm_run):

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -582,6 +582,14 @@ def test_set_item_nan_single(scm_run, key):
     assert all(np.isnan(scm_run[key]))
 
 
+@pytest.mark.parametrize("key", ("model", "junk"))
+def test_set_item_nan_float(scm_run, key):
+    scm_run[key] = [1, np.NaN, 2]
+    assert scm_run[key][0] == 1
+    assert np.isnan(scm_run[key][1])
+    assert scm_run[key][2] == 2
+
+
 def test_len(scm_run):
     assert len(scm_run) == len(scm_run.timeseries())
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -554,12 +554,32 @@ def test_set_item(scm_run):
     assert all(scm_run["model"] == ["a_iam", "b_iam", "c_iam"])
 
 
+def test_set_item_single(scm_run):
+    scm_run["model"] = "b_iam"
+    assert all(scm_run["model"] == ["b_iam", "b_iam", "b_iam"])
+
+
 def test_set_item_not_in_meta(scm_run):
     with pytest.raises(ValueError):
         scm_run["junk"] = ["hi", "bye"]
 
     scm_run["junk"] = ["hi", "bye", "ciao"]
     assert all(scm_run["junk"] == ["hi", "bye", "ciao"])
+
+    scm_run["junk"] = ["hi", "bye", "bye"]
+    assert all(scm_run["junk"] == ["hi", "bye", "bye"])
+
+
+@pytest.mark.parametrize("key", ("model", "junk"))
+def test_set_item_nan(scm_run, key):
+    scm_run[key] = ["hi", np.NaN, "bye"]
+    assert all(scm_run[key] == ["hi", "nan", "bye"])
+
+
+@pytest.mark.parametrize("key", ("model", "junk"))
+def test_set_item_nan_single(scm_run, key):
+    scm_run[key] = np.nan
+    assert all(np.isnan(scm_run[key]))
 
 
 def test_len(scm_run):

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -606,6 +606,12 @@ class TestSetItem:
         filtered2["new_key"] = "third model"
         assert "new_key" not in scm_run.meta.columns
 
+    def test_filter_remove(self, scm_run):
+        scm_run["new_key"] = "test_model"
+        filtered = scm_run.filter(variable="Primary Energy|Coal").drop_meta("new_key")
+
+        assert "new_key" not in filtered.meta_attributes
+        assert "new_key" in scm_run.meta_attributes
 
 def test_len(scm_run):
     assert len(scm_run) == len(scm_run.timeseries())


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [ ] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added

# Content

Create the changed MultiIndex via levels and codes instead of via a DataFrame for better performance.

# Benchmarks

I benchmarked setting metadata on a run with 5000 rows. I only benchmarked overwriting existing metadata for practical reasons, but the performance should be similar.

<details><summary>Benchmarking code</summary>

```python

import scmdata
import numpy as np


def create_run():
    years = np.arange(1990, 2010)
    n = 5000
    return scmdata.ScmRun(
        np.ones((len(years), n), dtype=float),
        years,
        {
            "variable": [str(x) for x in range(n)],
            "unit": ["Mt CO2 / year"] * n,
            "category": ["0"] * n,
            "model": ["TEST"] * n,
            "scenario": ["TEST"] * n,
            "region": ["WORLD"] * n,
            "stage": ["test"] * n,
        },
    )


import timeit

single_existing = timeit.timeit(
    "a['scenario'] = 'This is not a test'",
    setup="a = create_run()",
    globals=globals(),
    number=1000,
)
print(f"{single_existing=}")
multi_existing = timeit.timeit(
    "a['scenario'] = b",
    setup="a = create_run(); b = ['This is not a test'] * 5000",
    globals=globals(),
    number=1000,
)
print(f"{multi_existing=}")
```
</details>


old, 1000 executions:
single_existing=1.4 s
multi_existing=1.3 s

new, 1000 executions:
single_existing=0.20 s
multi_existing=0.79 s


So, for the common case of replacing all values with a single new value, we get a 7 times speedup, for the case where we replace with a full set of new values, the speedup is 1.6.